### PR TITLE
Release 0.2.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "wristband-django-auth"
-version = "0.1.1"
+version = "0.2.0"
 description = "SDK for integrating your Python Django application with Wristband. Handles user authentication and token management."
 readme = "README_PYPI.md"
 license = "MIT"

--- a/src/wristband/django_auth/config_resolver.py
+++ b/src/wristband/django_auth/config_resolver.py
@@ -1,0 +1,321 @@
+import threading
+import time
+from typing import Optional
+
+from .client import WristbandApiClient
+from .exceptions import WristbandError
+from .models import AuthConfig, SdkConfiguration
+
+_default_scopes = ["openid", "offline_access", "email"]
+_max_fetch_attempts = 3
+_attempt_delay_seconds = 0.1  # 100 milliseconds
+_tenant_domain_token: str = "{tenant_domain}"
+
+
+class ConfigResolver:
+    """
+    Resolves and validates Wristband authentication configuration, supporting both
+    manual configuration and auto-configuration via the Wristband SDK configuration endpoint.
+
+    NOTE: This is a synchronous implementation.
+    """
+
+    def __init__(self, auth_config: AuthConfig) -> None:
+        self.auth_config = auth_config
+        self.sdk_config_cache: Optional[SdkConfiguration] = None
+        self._config_lock = threading.Lock()
+
+        # Always validate required configs
+        self._validate_required_auth_configs()
+
+        if self.get_auto_configure_enabled():
+            # Only validate manually provided values when auto-configure is enabled
+            self._validate_partial_url_auth_configs()
+        else:
+            # Validate all URL configs if auto-configure is disabled
+            self._validate_strict_url_auth_configs()
+
+        self.wristband_api = WristbandApiClient(
+            auth_config.wristband_application_vanity_domain,
+            auth_config.client_id,
+            auth_config.client_secret,
+        )
+
+    def preload_sdk_config(self) -> None:
+        """Preload SDK configuration (eager loading)."""
+        self._load_sdk_config()
+
+    def _load_sdk_config(self) -> SdkConfiguration:
+        """Load SDK configuration with caching and thread safety."""
+        # Return cached config if available
+        if self.sdk_config_cache:
+            return self.sdk_config_cache
+
+        with self._config_lock:
+            # Double-check pattern: other thread may have loaded while waiting for the lock
+            if self.sdk_config_cache:
+                return self.sdk_config_cache
+
+            # We're the first thread here, fetch and cache the configuration
+            self.sdk_config_cache = self._fetch_sdk_configuration()
+            self._validate_all_dynamic_configs(self.sdk_config_cache)
+            return self.sdk_config_cache
+
+    def _fetch_sdk_configuration(self) -> SdkConfiguration:
+        """Fetch SDK configuration with retry logic."""
+        last_error: Optional[Exception] = None
+
+        for attempt in range(1, _max_fetch_attempts + 1):
+            try:
+                config = self.wristband_api.get_sdk_configuration()
+                return config
+            except Exception as error:
+                last_error = error
+
+                # Final attempt failed, break and throw
+                if attempt == _max_fetch_attempts:
+                    break
+
+                # Wait before retrying
+                time.sleep(_attempt_delay_seconds)
+
+        error_message = f"Failed to fetch SDK configuration after {_max_fetch_attempts} attempts"
+        if last_error:
+            error_message += f": {str(last_error)}"
+        else:
+            error_message += ": Unknown error"
+
+        raise WristbandError("sdk_config_fetch_failed", error_message)
+
+    def _validate_required_auth_configs(self) -> None:
+        """Validate required authentication configuration fields."""
+        if not self.auth_config.client_id or not self.auth_config.client_id.strip():
+            raise TypeError("The [client_id] config must have a value.")
+        if not self.auth_config.client_secret or not self.auth_config.client_secret.strip():
+            raise TypeError("The [client_secret] config must have a value.")
+        if self.auth_config.login_state_secret and len(self.auth_config.login_state_secret) < 32:
+            raise TypeError("The [login_state_secret] config must have a value of at least 32 characters.")
+        if (
+            not self.auth_config.wristband_application_vanity_domain
+            or not self.auth_config.wristband_application_vanity_domain.strip()
+        ):
+            raise TypeError("The [wristband_application_vanity_domain] config must have a value.")
+        if self.auth_config.token_expiration_buffer < 0:
+            raise TypeError("The [token_expiration_buffer] config must be greater than or equal to 0.")
+
+    def _validate_strict_url_auth_configs(self) -> None:
+        """Validate URL configuration when auto-configure is disabled."""
+        if not self.auth_config.login_url or not self.auth_config.login_url.strip():
+            raise TypeError("The [login_url] config must have a value when auto-configure is disabled.")
+        if not self.auth_config.redirect_uri or not self.auth_config.redirect_uri.strip():
+            raise TypeError("The [redirect_uri] config must have a value when auto-configure is disabled.")
+
+        if self.auth_config.parse_tenant_from_root_domain and self.auth_config.parse_tenant_from_root_domain.strip():
+            if _tenant_domain_token not in self.auth_config.login_url:
+                raise TypeError(
+                    'The [login_url] must contain the "{tenant_domain}" token when using the '
+                    "[parse_tenant_from_root_domain] config."
+                )
+            if _tenant_domain_token not in self.auth_config.redirect_uri:
+                raise TypeError(
+                    'The [redirect_uri] must contain the "{tenant_domain}" token when using the '
+                    "[parse_tenant_from_root_domain] config."
+                )
+        else:
+            if _tenant_domain_token in self.auth_config.login_url:
+                raise TypeError(
+                    'The [login_url] cannot contain the "{tenant_domain}" token when the '
+                    "[parse_tenant_from_root_domain] is absent."
+                )
+            if _tenant_domain_token in self.auth_config.redirect_uri:
+                raise TypeError(
+                    'The [redirect_uri] cannot contain the "{tenant_domain}" token when the '
+                    "[parse_tenant_from_root_domain] is absent."
+                )
+
+    def _validate_partial_url_auth_configs(self) -> None:
+        """Validate manually provided URL configuration when auto-configure is enabled."""
+        tenant_parsing_enabled = (
+            self.auth_config.parse_tenant_from_root_domain and self.auth_config.parse_tenant_from_root_domain.strip()
+        )
+
+        if self.auth_config.login_url:
+            if tenant_parsing_enabled and _tenant_domain_token not in self.auth_config.login_url:
+                raise TypeError(
+                    'The [login_url] must contain the "{tenant_domain}" token when using the '
+                    "[parse_tenant_from_root_domain] config."
+                )
+            if not tenant_parsing_enabled and _tenant_domain_token in self.auth_config.login_url:
+                raise TypeError(
+                    'The [login_url] cannot contain the "{tenant_domain}" token when the '
+                    "[parse_tenant_from_root_domain] is absent."
+                )
+
+        if self.auth_config.redirect_uri:
+            if tenant_parsing_enabled and _tenant_domain_token not in self.auth_config.redirect_uri:
+                raise TypeError(
+                    'The [redirect_uri] must contain the "{tenant_domain}" token when using the '
+                    "[parse_tenant_from_root_domain] config."
+                )
+            if not tenant_parsing_enabled and _tenant_domain_token in self.auth_config.redirect_uri:
+                raise TypeError(
+                    'The [redirect_uri] cannot contain the "{tenant_domain}" token when the '
+                    "[parse_tenant_from_root_domain] is absent."
+                )
+
+    def _validate_all_dynamic_configs(self, sdk_configuration: SdkConfiguration) -> None:
+        """Validate all dynamic configurations after SDK config is loaded."""
+        # Validate that required fields are present in the SDK config response
+        if not sdk_configuration.login_url:
+            raise WristbandError("sdk_config_invalid", "SDK configuration response missing required field: login_url")
+        if not sdk_configuration.redirect_uri:
+            raise WristbandError(
+                "sdk_config_invalid", "SDK configuration response missing required field: redirect_uri"
+            )
+
+        # Use manual config values if provided, otherwise use SDK config values
+        login_url = self.auth_config.login_url or sdk_configuration.login_url
+        redirect_uri = self.auth_config.redirect_uri or sdk_configuration.redirect_uri
+
+        manual_tenant_parsing = (
+            self.auth_config.parse_tenant_from_root_domain and self.auth_config.parse_tenant_from_root_domain.strip()
+        )
+        parse_tenant_from_root_domain = manual_tenant_parsing or sdk_configuration.login_url_tenant_domain_suffix
+
+        # Validate the tenant domain token logic with final resolved values
+        if parse_tenant_from_root_domain:
+            if _tenant_domain_token not in login_url:
+                raise WristbandError(
+                    "config_validation_error",
+                    'The resolved [login_url] must contain the "{tenant_domain}" token when using '
+                    "[parse_tenant_from_root_domain].",
+                )
+            if _tenant_domain_token not in redirect_uri:
+                raise WristbandError(
+                    "config_validation_error",
+                    'The resolved [redirect_uri] must contain the "{tenant_domain}" token when using '
+                    "[parse_tenant_from_root_domain].",
+                )
+        else:
+            if _tenant_domain_token in login_url:
+                raise WristbandError(
+                    "config_validation_error",
+                    'The resolved [login_url] cannot contain the "{tenant_domain}" token when '
+                    "[parse_tenant_from_root_domain] is absent.",
+                )
+            if _tenant_domain_token in redirect_uri:
+                raise WristbandError(
+                    "config_validation_error",
+                    'The resolved [redirect_uri] cannot contain the "{tenant_domain}" token when '
+                    "[parse_tenant_from_root_domain] is absent.",
+                )
+
+    # ////////////////////////////////////
+    #  STATIC CONFIGURATIONS
+    # ////////////////////////////////////
+
+    def get_client_id(self) -> str:
+        """Get the client ID."""
+        return self.auth_config.client_id
+
+    def get_client_secret(self) -> str:
+        """Get the client secret."""
+        return self.auth_config.client_secret
+
+    def get_login_state_secret(self) -> str:
+        """Get the login state secret, falling back to client secret if not provided."""
+        return self.auth_config.login_state_secret or self.auth_config.client_secret
+
+    def get_wristband_application_vanity_domain(self) -> str:
+        """Get the Wristband application vanity domain."""
+        return self.auth_config.wristband_application_vanity_domain
+
+    def get_dangerously_disable_secure_cookies(self) -> bool:
+        """Get whether to disable secure cookies (for development only)."""
+        return self.auth_config.dangerously_disable_secure_cookies
+
+    def get_scopes(self) -> list[str]:
+        """Get the OAuth scopes, using defaults if not provided."""
+        return self.auth_config.scopes if self.auth_config.scopes else _default_scopes
+
+    def get_auto_configure_enabled(self) -> bool:
+        """Get whether auto-configuration is enabled."""
+        return self.auth_config.auto_configure_enabled
+
+    def get_token_expiration_buffer(self) -> int:
+        """Get the token expiration buffer in seconds."""
+        return self.auth_config.token_expiration_buffer
+
+    # ////////////////////////////////////
+    #  DYNAMIC CONFIGURATIONS
+    # ////////////////////////////////////
+
+    def get_custom_application_login_page_url(self) -> str:
+        """Get the custom application login page URL."""
+        # 1. Check if manually provided in authConfig
+        if self.auth_config.custom_application_login_page_url:
+            return self.auth_config.custom_application_login_page_url
+
+        # 2. If auto-configure is enabled, get from SDK config
+        if self.get_auto_configure_enabled():
+            sdk_config = self._load_sdk_config()
+            return sdk_config.custom_application_login_page_url or ""
+
+        # 3. Default fallback
+        return ""
+
+    def get_is_application_custom_domain_active(self) -> bool:
+        """Get whether application custom domain is active."""
+        # 1. Check if manually provided in authConfig
+        if self.auth_config.is_application_custom_domain_active is not None:
+            return self.auth_config.is_application_custom_domain_active
+
+        # 2. If auto-configure is enabled, get from SDK config
+        if self.get_auto_configure_enabled():
+            sdk_config = self._load_sdk_config()
+            return sdk_config.is_application_custom_domain_active
+
+        # 3. Default fallback
+        return False
+
+    def get_login_url(self) -> str:
+        """Get the login URL."""
+        # 1. Check if manually provided in authConfig
+        if self.auth_config.login_url:
+            return self.auth_config.login_url
+
+        # 2. If auto-configure is enabled, get from SDK config
+        if self.get_auto_configure_enabled():
+            sdk_config = self._load_sdk_config()
+            return sdk_config.login_url
+
+        # 3. This should not happen if validation is done properly
+        raise TypeError("The [login_url] config must have a value")
+
+    def get_parse_tenant_from_root_domain(self) -> str:
+        """Get the root domain for parsing tenant subdomains."""
+        # 1. Check if manually provided in authConfig
+        if self.auth_config.parse_tenant_from_root_domain:
+            return self.auth_config.parse_tenant_from_root_domain
+
+        # 2. If auto-configure is enabled, get from SDK config
+        if self.get_auto_configure_enabled():
+            sdk_config = self._load_sdk_config()
+            return sdk_config.login_url_tenant_domain_suffix or ""
+
+        # 3. Default fallback
+        return ""
+
+    def get_redirect_uri(self) -> str:
+        """Get the redirect URI."""
+        # 1. Check if manually provided in authConfig
+        if self.auth_config.redirect_uri:
+            return self.auth_config.redirect_uri
+
+        # 2. If auto-configure is enabled, get from SDK config
+        if self.get_auto_configure_enabled():
+            sdk_config = self._load_sdk_config()
+            return sdk_config.redirect_uri
+
+        # 3. This should not happen if validation is done properly
+        raise TypeError("The [redirect_uri] config must have a value")

--- a/tests/auth/test_discover.py
+++ b/tests/auth/test_discover.py
@@ -1,0 +1,42 @@
+from unittest.mock import Mock
+
+import pytest
+
+from wristband.django_auth.auth import WristbandAuth
+from wristband.django_auth.exceptions import WristbandError
+from wristband.django_auth.models import AuthConfig
+
+
+@pytest.fixture
+def mock_auth_config():
+    return AuthConfig(
+        client_id="test-client",
+        client_secret="test-secret",
+        login_state_secret="a" * 32,
+        login_url="https://example.com/login",
+        redirect_uri="https://example.com/callback",
+        wristband_application_vanity_domain="example.wristband.dev",
+        auto_configure_enabled=True,
+    )
+
+
+def test_discover_raises_if_auto_configure_disabled(mock_auth_config):
+    mock_auth_config.auto_configure_enabled = False
+    auth = WristbandAuth(mock_auth_config)
+
+    with pytest.raises(WristbandError) as exc:
+        auth.discover()
+
+    assert "auto_configure_enabled is false" in str(exc.value)
+
+
+def test_discover_calls_preload_sdk_config(mock_auth_config):
+    auth = WristbandAuth(mock_auth_config)
+
+    # Patch resolver to spy on preload_sdk_config
+    mock_preload = Mock()
+    auth._config_resolver.preload_sdk_config = mock_preload
+
+    auth.discover()
+
+    mock_preload.assert_called_once()

--- a/tests/test_config_resolver.py
+++ b/tests/test_config_resolver.py
@@ -1,0 +1,1218 @@
+import threading
+import time
+from unittest.mock import Mock, patch
+
+import pytest
+
+from wristband.django_auth.config_resolver import ConfigResolver
+from wristband.django_auth.exceptions import WristbandError
+from wristband.django_auth.models import AuthConfig, SdkConfiguration
+
+
+class TestConfigResolverValidation:
+    """Test cases for ConfigResolver validation logic."""
+
+    def test_validate_client_id_empty(self):
+        """Test validation fails with empty client_id."""
+        config = AuthConfig(
+            client_id="",
+            client_secret="test_secret",
+            wristband_application_vanity_domain="test.wristband.dev",
+        )
+
+        with pytest.raises(TypeError, match="The \\[client_id\\] config must have a value."):
+            ConfigResolver(config)
+
+    def test_validate_client_id_whitespace(self):
+        """Test validation fails with whitespace-only client_id."""
+        config = AuthConfig(
+            client_id="   ",
+            client_secret="test_secret",
+            wristband_application_vanity_domain="test.wristband.dev",
+        )
+
+        with pytest.raises(TypeError, match="The \\[client_id\\] config must have a value."):
+            ConfigResolver(config)
+
+    def test_validate_client_secret_empty(self):
+        """Test validation fails with empty client_secret."""
+        config = AuthConfig(
+            client_id="test_client",
+            client_secret="",
+            wristband_application_vanity_domain="test.wristband.dev",
+        )
+
+        with pytest.raises(TypeError, match="The \\[client_secret\\] config must have a value."):
+            ConfigResolver(config)
+
+    def test_validate_client_secret_whitespace(self):
+        """Test validation fails with whitespace-only client_secret."""
+        config = AuthConfig(
+            client_id="test_client",
+            client_secret="   ",
+            wristband_application_vanity_domain="test.wristband.dev",
+        )
+
+        with pytest.raises(TypeError, match="The \\[client_secret\\] config must have a value."):
+            ConfigResolver(config)
+
+    def test_validate_login_state_secret_too_short(self):
+        """Test validation fails with short login_state_secret."""
+        config = AuthConfig(
+            client_id="test_client",
+            client_secret="test_secret",
+            wristband_application_vanity_domain="test.wristband.dev",
+            login_state_secret="short",
+        )
+
+        with pytest.raises(
+            TypeError, match="The \\[login_state_secret\\] config must have a value of at least 32 characters."
+        ):
+            ConfigResolver(config)
+
+    def test_validate_login_state_secret_none_allowed(self):
+        """Test validation passes with None login_state_secret."""
+        config = AuthConfig(
+            client_id="test_client",
+            client_secret="test_secret",
+            wristband_application_vanity_domain="test.wristband.dev",
+            login_state_secret=None,
+        )
+
+        # Should not raise
+        ConfigResolver(config)
+
+    def test_validate_vanity_domain_empty(self):
+        """Test validation fails with empty vanity domain."""
+        config = AuthConfig(
+            client_id="test_client",
+            client_secret="test_secret",
+            wristband_application_vanity_domain="",
+        )
+
+        with pytest.raises(TypeError, match="The \\[wristband_application_vanity_domain\\] config must have a value."):
+            ConfigResolver(config)
+
+    def test_validate_vanity_domain_whitespace(self):
+        """Test validation fails with whitespace-only vanity domain."""
+        config = AuthConfig(
+            client_id="test_client",
+            client_secret="test_secret",
+            wristband_application_vanity_domain="   ",
+        )
+
+        with pytest.raises(TypeError, match="The \\[wristband_application_vanity_domain\\] config must have a value."):
+            ConfigResolver(config)
+
+    def test_validate_token_expiration_buffer_negative(self):
+        """Test validation fails with negative token_expiration_buffer."""
+        config = AuthConfig(
+            client_id="test_client",
+            client_secret="test_secret",
+            wristband_application_vanity_domain="test.wristband.dev",
+            token_expiration_buffer=-1,
+        )
+
+        with pytest.raises(
+            TypeError, match="The \\[token_expiration_buffer\\] config must be greater than or equal to 0."
+        ):
+            ConfigResolver(config)
+
+    def test_validate_auto_configure_disabled_missing_login_url(self):
+        """Test validation fails when auto-configure disabled and login_url missing."""
+        config = AuthConfig(
+            client_id="test_client",
+            client_secret="test_secret",
+            wristband_application_vanity_domain="test.wristband.dev",
+            auto_configure_enabled=False,
+        )
+
+        with pytest.raises(
+            TypeError, match="The \\[login_url\\] config must have a value when auto-configure is disabled."
+        ):
+            ConfigResolver(config)
+
+    def test_validate_auto_configure_disabled_missing_redirect_uri(self):
+        """Test validation fails when auto-configure disabled and redirect_uri missing."""
+        config = AuthConfig(
+            client_id="test_client",
+            client_secret="test_secret",
+            wristband_application_vanity_domain="test.wristband.dev",
+            auto_configure_enabled=False,
+            login_url="https://test.com/login",
+        )
+
+        with pytest.raises(
+            TypeError, match="The \\[redirect_uri\\] config must have a value when auto-configure is disabled."
+        ):
+            ConfigResolver(config)
+
+    def test_validate_tenant_domain_token_missing_in_login_url(self):
+        """Test validation fails when tenant domain token missing from login_url."""
+        config = AuthConfig(
+            client_id="test_client",
+            client_secret="test_secret",
+            wristband_application_vanity_domain="test.wristband.dev",
+            auto_configure_enabled=False,
+            login_url="https://test.com/login",
+            redirect_uri="https://{tenant_domain}.test.com/callback",
+            parse_tenant_from_root_domain="test.com",
+        )
+
+        with pytest.raises(TypeError, match='The \\[login_url\\] must contain the "\\{tenant_domain\\}" token'):
+            ConfigResolver(config)
+
+    def test_validate_tenant_domain_token_missing_in_redirect_uri(self):
+        """Test validation fails when tenant domain token missing from redirect_uri."""
+        config = AuthConfig(
+            client_id="test_client",
+            client_secret="test_secret",
+            wristband_application_vanity_domain="test.wristband.dev",
+            auto_configure_enabled=False,
+            login_url="https://{tenant_domain}.test.com/login",
+            redirect_uri="https://test.com/callback",
+            parse_tenant_from_root_domain="test.com",
+        )
+
+        with pytest.raises(TypeError, match='The \\[redirect_uri\\] must contain the "\\{tenant_domain\\}" token'):
+            ConfigResolver(config)
+
+    def test_validate_tenant_domain_token_present_without_parsing(self):
+        """Test validation fails when tenant domain token present but parsing disabled."""
+        config = AuthConfig(
+            client_id="test_client",
+            client_secret="test_secret",
+            wristband_application_vanity_domain="test.wristband.dev",
+            auto_configure_enabled=False,
+            login_url="https://{tenant_domain}.test.com/login",
+            redirect_uri="https://test.com/callback",
+        )
+
+        with pytest.raises(TypeError, match='The \\[login_url\\] cannot contain the "\\{tenant_domain\\}" token'):
+            ConfigResolver(config)
+
+    def test_validate_partial_url_configs_with_auto_configure(self):
+        """Test validation of partial URL configs when auto-configure is enabled."""
+        config = AuthConfig(
+            client_id="test_client",
+            client_secret="test_secret",
+            wristband_application_vanity_domain="test.wristband.dev",
+            auto_configure_enabled=True,
+            login_url="https://test.com/login",
+            parse_tenant_from_root_domain="test.com",
+        )
+
+        with pytest.raises(TypeError, match='The \\[login_url\\] must contain the "\\{tenant_domain\\}" token'):
+            ConfigResolver(config)
+
+    def test_valid_configuration_passes(self):
+        """Test that valid configuration passes validation."""
+        config = AuthConfig(
+            client_id="test_client",
+            client_secret="test_secret",
+            wristband_application_vanity_domain="test.wristband.dev",
+            auto_configure_enabled=False,
+            login_url="https://{tenant_domain}.test.com/login",
+            redirect_uri="https://{tenant_domain}.test.com/callback",
+            parse_tenant_from_root_domain="test.com",
+            login_state_secret="a" * 32,
+        )
+
+        # Should not raise
+        resolver = ConfigResolver(config)
+        assert resolver is not None
+
+
+class TestConfigResolverStaticConfigurations:
+    """Test cases for static configuration getters."""
+
+    def setup_method(self):
+        """Set up test fixtures."""
+        self.config = AuthConfig(
+            client_id="test_client",
+            client_secret="test_secret",
+            wristband_application_vanity_domain="test.wristband.dev",
+            login_state_secret="a" * 32,
+            dangerously_disable_secure_cookies=True,
+            scopes=["custom", "scopes"],
+            token_expiration_buffer=120,
+        )
+        self.resolver = ConfigResolver(self.config)
+
+    def test_get_client_id(self):
+        """Test get_client_id returns correct value."""
+        assert self.resolver.get_client_id() == "test_client"
+
+    def test_get_client_secret(self):
+        """Test get_client_secret returns correct value."""
+        assert self.resolver.get_client_secret() == "test_secret"
+
+    def test_get_login_state_secret_custom(self):
+        """Test get_login_state_secret returns custom value when provided."""
+        assert self.resolver.get_login_state_secret() == "a" * 32
+
+    def test_get_login_state_secret_fallback(self):
+        """Test get_login_state_secret falls back to client_secret."""
+        config = AuthConfig(
+            client_id="test_client",
+            client_secret="test_secret",
+            wristband_application_vanity_domain="test.wristband.dev",
+        )
+        resolver = ConfigResolver(config)
+        assert resolver.get_login_state_secret() == "test_secret"
+
+    def test_get_wristband_application_vanity_domain(self):
+        """Test get_wristband_application_vanity_domain returns correct value."""
+        assert self.resolver.get_wristband_application_vanity_domain() == "test.wristband.dev"
+
+    def test_get_dangerously_disable_secure_cookies_true(self):
+        """Test get_dangerously_disable_secure_cookies when set to True."""
+        assert self.resolver.get_dangerously_disable_secure_cookies() is True
+
+    def test_get_dangerously_disable_secure_cookies_default(self):
+        """Test get_dangerously_disable_secure_cookies default value."""
+        config = AuthConfig(
+            client_id="test_client",
+            client_secret="test_secret",
+            wristband_application_vanity_domain="test.wristband.dev",
+        )
+        resolver = ConfigResolver(config)
+        assert resolver.get_dangerously_disable_secure_cookies() is False
+
+    def test_get_scopes_custom(self):
+        """Test get_scopes returns custom scopes."""
+        assert self.resolver.get_scopes() == ["custom", "scopes"]
+
+    def test_get_scopes_default(self):
+        """Test get_scopes returns default scopes."""
+        config = AuthConfig(
+            client_id="test_client",
+            client_secret="test_secret",
+            wristband_application_vanity_domain="test.wristband.dev",
+        )
+        resolver = ConfigResolver(config)
+        assert resolver.get_scopes() == ["openid", "offline_access", "email"]
+
+    def test_get_scopes_empty_list_uses_default(self):
+        """Test get_scopes uses defaults when empty list provided."""
+        config = AuthConfig(
+            client_id="test_client",
+            client_secret="test_secret",
+            wristband_application_vanity_domain="test.wristband.dev",
+            scopes=[],
+        )
+        resolver = ConfigResolver(config)
+        assert resolver.get_scopes() == ["openid", "offline_access", "email"]
+
+    def test_get_auto_configure_enabled_default(self):
+        """Test get_auto_configure_enabled returns default True."""
+        config = AuthConfig(
+            client_id="test_client",
+            client_secret="test_secret",
+            wristband_application_vanity_domain="test.wristband.dev",
+        )
+        resolver = ConfigResolver(config)
+        assert resolver.get_auto_configure_enabled() is True
+
+    def test_get_auto_configure_enabled_false(self):
+        """Test get_auto_configure_enabled when set to False."""
+        config = AuthConfig(
+            client_id="test_client",
+            client_secret="test_secret",
+            wristband_application_vanity_domain="test.wristband.dev",
+            auto_configure_enabled=False,
+            login_url="https://test.com/login",
+            redirect_uri="https://test.com/callback",
+        )
+        resolver = ConfigResolver(config)
+        assert resolver.get_auto_configure_enabled() is False
+
+    def test_get_token_expiration_buffer_custom(self):
+        """Test get_token_expiration_buffer returns custom value."""
+        assert self.resolver.get_token_expiration_buffer() == 120
+
+    def test_get_token_expiration_buffer_default(self):
+        """Test get_token_expiration_buffer returns default value."""
+        config = AuthConfig(
+            client_id="test_client",
+            client_secret="test_secret",
+            wristband_application_vanity_domain="test.wristband.dev",
+        )
+        resolver = ConfigResolver(config)
+        assert resolver.get_token_expiration_buffer() == 60
+
+
+class TestConfigResolverDynamicConfigurations:
+    """Test cases for dynamic configuration getters."""
+
+    def setup_method(self):
+        """Set up test fixtures."""
+        self.valid_sdk_config = SdkConfiguration(
+            login_url="https://sdk.example.com/login",
+            redirect_uri="https://sdk.example.com/callback",
+            custom_application_login_page_url="https://sdk.example.com/custom-login",
+            is_application_custom_domain_active=True,
+            login_url_tenant_domain_suffix=None,
+        )
+
+    def test_manual_config_takes_precedence(self):
+        """Test that manual configuration takes precedence over auto-config."""
+        config = AuthConfig(
+            client_id="test_client",
+            client_secret="test_secret",
+            wristband_application_vanity_domain="test.wristband.dev",
+            login_url="https://{tenant_domain}.manual.com/login",
+            redirect_uri="https://{tenant_domain}.manual.com/callback",
+            custom_application_login_page_url="https://manual.com/custom",
+            is_application_custom_domain_active=False,
+            parse_tenant_from_root_domain="manual.com",
+        )
+
+        with patch("wristband.django_auth.config_resolver.WristbandApiClient") as mock_client_class:
+            mock_client = Mock()
+            mock_client.get_sdk_configuration = Mock(return_value=self.valid_sdk_config)
+            mock_client_class.return_value = mock_client
+
+            resolver = ConfigResolver(config)
+
+            assert resolver.get_login_url() == "https://{tenant_domain}.manual.com/login"
+            assert resolver.get_redirect_uri() == "https://{tenant_domain}.manual.com/callback"
+            assert resolver.get_custom_application_login_page_url() == "https://manual.com/custom"
+            assert resolver.get_is_application_custom_domain_active() is False
+            assert resolver.get_parse_tenant_from_root_domain() == "manual.com"
+
+    def test_auto_config_fallback(self):
+        """Test auto-configuration fallback when manual values not provided."""
+        config = AuthConfig(
+            client_id="test_client",
+            client_secret="test_secret",
+            wristband_application_vanity_domain="test.wristband.dev",
+            auto_configure_enabled=True,
+        )
+
+        with patch("wristband.django_auth.config_resolver.WristbandApiClient") as mock_client_class:
+            mock_client = Mock()
+            mock_client.get_sdk_configuration = Mock(return_value=self.valid_sdk_config)
+            mock_client_class.return_value = mock_client
+
+            resolver = ConfigResolver(config)
+
+            assert resolver.get_login_url() == "https://sdk.example.com/login"
+            assert resolver.get_redirect_uri() == "https://sdk.example.com/callback"
+            assert resolver.get_custom_application_login_page_url() == "https://sdk.example.com/custom-login"
+            assert resolver.get_is_application_custom_domain_active() is True
+            assert resolver.get_parse_tenant_from_root_domain() == ""
+
+    def test_auto_config_disabled_fallbacks(self):
+        """Test fallback values when auto-config is disabled."""
+        config = AuthConfig(
+            client_id="test_client",
+            client_secret="test_secret",
+            wristband_application_vanity_domain="test.wristband.dev",
+            auto_configure_enabled=False,
+            login_url="https://manual.com/login",
+            redirect_uri="https://manual.com/callback",
+        )
+        resolver = ConfigResolver(config)
+
+        assert resolver.get_custom_application_login_page_url() == ""
+        assert resolver.get_is_application_custom_domain_active() is False
+        assert resolver.get_parse_tenant_from_root_domain() == ""
+
+    def test_auto_config_none_values(self):
+        """Test handling of None values from auto-config."""
+        sdk_config = SdkConfiguration(
+            login_url="https://sdk.example.com/login",
+            redirect_uri="https://sdk.example.com/callback",
+            custom_application_login_page_url=None,
+            is_application_custom_domain_active=False,
+            login_url_tenant_domain_suffix=None,
+        )
+
+        config = AuthConfig(
+            client_id="test_client",
+            client_secret="test_secret",
+            wristband_application_vanity_domain="test.wristband.dev",
+            auto_configure_enabled=True,
+        )
+
+        with patch.object(ConfigResolver, "_load_sdk_config") as mock_load:
+            mock_load.return_value = sdk_config
+            resolver = ConfigResolver(config)
+
+            assert resolver.get_custom_application_login_page_url() == ""
+            assert resolver.get_is_application_custom_domain_active() is False
+            assert resolver.get_parse_tenant_from_root_domain() == ""
+
+
+class TestConfigResolverSdkConfigFetching:
+    """Test cases for SDK configuration fetching and caching."""
+
+    def setup_method(self):
+        """Set up test fixtures."""
+        self.config = AuthConfig(
+            client_id="test_client",
+            client_secret="test_secret",
+            wristband_application_vanity_domain="test.wristband.dev",
+        )
+        self.valid_sdk_config = SdkConfiguration(
+            login_url="https://sdk.example.com/login",
+            redirect_uri="https://sdk.example.com/callback",
+            is_application_custom_domain_active=True,
+        )
+
+    def test_sdk_config_caching(self):
+        """Test that SDK config is cached after first fetch."""
+        with patch("wristband.django_auth.config_resolver.WristbandApiClient") as mock_client_class:
+            mock_client = Mock()
+            mock_client.get_sdk_configuration = Mock(return_value=self.valid_sdk_config)
+            mock_client_class.return_value = mock_client
+
+            resolver = ConfigResolver(self.config)
+
+            # First call should fetch
+            result1 = resolver.get_login_url()
+            assert result1 == "https://sdk.example.com/login"
+
+            # Second call should use cache
+            result2 = resolver.get_redirect_uri()
+            assert result2 == "https://sdk.example.com/callback"
+
+            # Should only have called the API once
+            mock_client.get_sdk_configuration.assert_called_once()
+
+    def test_sdk_config_retry_logic(self):
+        """Test retry logic for SDK config fetching."""
+        with patch("wristband.django_auth.config_resolver.WristbandApiClient") as mock_client_class:
+            mock_client = Mock()
+            # Fail twice, succeed on third attempt
+            mock_client.get_sdk_configuration = Mock(
+                side_effect=[Exception("Network error 1"), Exception("Network error 2"), self.valid_sdk_config]
+            )
+            mock_client_class.return_value = mock_client
+
+            resolver = ConfigResolver(self.config)
+
+            result = resolver.get_login_url()
+            assert result == "https://sdk.example.com/login"
+            assert mock_client.get_sdk_configuration.call_count == 3
+
+    def test_sdk_config_fetch_failure_after_max_retries(self):
+        """Test failure after maximum retry attempts."""
+        with patch("wristband.django_auth.config_resolver.WristbandApiClient") as mock_client_class:
+            mock_client = Mock()
+            mock_client.get_sdk_configuration = Mock(side_effect=Exception("Persistent network error"))
+            mock_client_class.return_value = mock_client
+
+            resolver = ConfigResolver(self.config)
+
+            with pytest.raises(WristbandError) as exc_info:
+                resolver.get_login_url()
+
+            assert exc_info.value.error == "sdk_config_fetch_failed"
+            assert "Failed to fetch SDK configuration after 3 attempts" in exc_info.value.error_description
+            assert mock_client.get_sdk_configuration.call_count == 3
+
+    def test_preload_sdk_config(self):
+        """Test preload_sdk_config method."""
+        with patch("wristband.django_auth.config_resolver.WristbandApiClient") as mock_client_class:
+            mock_client = Mock()
+            mock_client.get_sdk_configuration = Mock(return_value=self.valid_sdk_config)
+            mock_client_class.return_value = mock_client
+
+            resolver = ConfigResolver(self.config)
+
+            # Preload config
+            resolver.preload_sdk_config()
+            assert mock_client.get_sdk_configuration.call_count == 1
+
+            # Subsequent calls should use cache
+            result = resolver.get_login_url()
+            assert result == "https://sdk.example.com/login"
+            assert mock_client.get_sdk_configuration.call_count == 1
+
+    def test_thread_safety_multiple_threads(self):
+        """Test that multiple threads don't cause duplicate requests."""
+        with patch("wristband.django_auth.config_resolver.WristbandApiClient") as mock_client_class:
+            mock_client = Mock()
+
+            # Add delay to simulate network request
+            def delayed_response():
+                time.sleep(0.1)
+                return self.valid_sdk_config
+
+            mock_client.get_sdk_configuration = Mock(side_effect=delayed_response)
+            mock_client_class.return_value = mock_client
+
+            resolver = ConfigResolver(self.config)
+            results = []
+            exceptions = []
+
+            def worker():
+                try:
+                    result = resolver.get_login_url()
+                    results.append(result)
+                except Exception as e:
+                    exceptions.append(e)
+
+            # Create multiple threads
+            threads = [threading.Thread(target=worker) for _ in range(3)]
+
+            # Start all threads
+            for thread in threads:
+                thread.start()
+
+            # Wait for all threads to complete
+            for thread in threads:
+                thread.join()
+
+            # Should only have made one API call
+            mock_client.get_sdk_configuration.assert_called_once()
+            assert len(exceptions) == 0
+            assert all(result == "https://sdk.example.com/login" for result in results)
+
+    def test_error_allows_retry_after_failure(self):
+        """Test that errors reset to allow retry."""
+        with patch("wristband.django_auth.config_resolver.WristbandApiClient") as mock_client_class:
+            mock_client = Mock()
+            mock_client.get_sdk_configuration = Mock(
+                side_effect=[
+                    Exception("First error"),
+                    Exception("Second error"),
+                    Exception("Third error"),
+                    self.valid_sdk_config,  # Success on retry
+                ]
+            )
+            mock_client_class.return_value = mock_client
+
+            resolver = ConfigResolver(self.config)
+
+            # First attempt should fail after 3 retries
+            with pytest.raises(WristbandError):
+                resolver.get_login_url()
+            assert mock_client.get_sdk_configuration.call_count == 3
+
+            # Second attempt should succeed
+            result = resolver.get_redirect_uri()
+            assert result == "https://sdk.example.com/callback"
+            assert mock_client.get_sdk_configuration.call_count == 4
+
+    def test_sdk_config_fetch_with_delay_and_retry(self):
+        """Test SDK config fetch with realistic network delays and retries."""
+        with patch("wristband.django_auth.config_resolver.WristbandApiClient") as mock_client_class:
+            mock_client = Mock()
+
+            # Simulate network timeouts then success
+            def delayed_error_then_success():
+                time.sleep(0.05)  # Small delay
+                if mock_client.get_sdk_configuration.call_count <= 2:
+                    raise Exception("Network timeout")
+                return SdkConfiguration(
+                    login_url="https://sdk.example.com/login",
+                    redirect_uri="https://sdk.example.com/callback",
+                    is_application_custom_domain_active=False,
+                )
+
+            mock_client.get_sdk_configuration = Mock(side_effect=delayed_error_then_success)
+            mock_client_class.return_value = mock_client
+
+            config = AuthConfig(
+                client_id="test_client",
+                client_secret="test_secret",
+                wristband_application_vanity_domain="test.wristband.dev",
+            )
+            resolver = ConfigResolver(config)
+
+            start_time = time.time()
+            result = resolver.get_login_url()
+            end_time = time.time()
+
+            # Should succeed on third attempt
+            assert result == "https://sdk.example.com/login"
+            assert mock_client.get_sdk_configuration.call_count == 3
+            # Should have taken some time due to retries and delays
+            assert end_time - start_time >= 0.15  # 3 calls * 0.05s delay + retry delays
+
+
+class TestConfigResolverDynamicValidation:
+    """Test cases for dynamic configuration validation."""
+
+    def setup_method(self):
+        """Set up test fixtures."""
+        self.config = AuthConfig(
+            client_id="test_client",
+            client_secret="test_secret",
+            wristband_application_vanity_domain="test.wristband.dev",
+        )
+
+    def test_validate_missing_login_url_in_sdk_config(self):
+        """Test validation fails when SDK config missing login_url."""
+        invalid_sdk_config = SdkConfiguration(
+            login_url="", redirect_uri="https://sdk.example.com/callback", is_application_custom_domain_active=False
+        )
+
+        with patch("wristband.django_auth.config_resolver.WristbandApiClient") as mock_client_class:
+            mock_client = Mock()
+            mock_client.get_sdk_configuration = Mock(return_value=invalid_sdk_config)
+            mock_client_class.return_value = mock_client
+
+            resolver = ConfigResolver(self.config)
+
+            with pytest.raises(WristbandError) as exc_info:
+                resolver.get_login_url()
+
+            assert exc_info.value.error == "sdk_config_invalid"
+            assert "missing required field: login_url" in exc_info.value.error_description
+
+    def test_validate_missing_redirect_uri_in_sdk_config(self):
+        """Test validation fails when SDK config missing redirect_uri."""
+        invalid_sdk_config = SdkConfiguration(
+            login_url="https://sdk.example.com/login", redirect_uri="", is_application_custom_domain_active=False
+        )
+
+        with patch("wristband.django_auth.config_resolver.WristbandApiClient") as mock_client_class:
+            mock_client = Mock()
+            mock_client.get_sdk_configuration = Mock(return_value=invalid_sdk_config)
+            mock_client_class.return_value = mock_client
+
+            resolver = ConfigResolver(self.config)
+
+            with pytest.raises(WristbandError) as exc_info:
+                resolver.get_redirect_uri()
+
+            assert exc_info.value.error == "sdk_config_invalid"
+            assert "missing required field: redirect_uri" in exc_info.value.error_description
+
+    def test_validate_resolved_config_with_tenant_domain(self):
+        """Test validation of resolved config with tenant domain parsing."""
+        # SDK config without tenant tokens
+        sdk_config = SdkConfiguration(
+            login_url="https://sdk.example.com/login",
+            redirect_uri="https://sdk.example.com/callback",
+            is_application_custom_domain_active=False,
+        )
+
+        # Manual config with tenant domain parsing
+        config = AuthConfig(
+            client_id="test_client",
+            client_secret="test_secret",
+            wristband_application_vanity_domain="test.wristband.dev",
+            parse_tenant_from_root_domain="test.com",
+        )
+
+        with patch("wristband.django_auth.config_resolver.WristbandApiClient") as mock_client_class:
+            mock_client = Mock()
+            mock_client.get_sdk_configuration = Mock(return_value=sdk_config)
+            mock_client_class.return_value = mock_client
+
+            resolver = ConfigResolver(config)
+
+            with pytest.raises(WristbandError) as exc_info:
+                resolver.get_login_url()
+
+            assert exc_info.value.error == "config_validation_error"
+            assert "must contain the" in exc_info.value.error_description
+            assert "tenant_domain" in exc_info.value.error_description
+
+    def test_validate_resolved_config_without_tenant_domain(self):
+        """Test validation fails when tenant token present but parsing disabled."""
+        # SDK config with tenant tokens
+        sdk_config = SdkConfiguration(
+            login_url="https://{tenant_domain}.sdk.example.com/login",
+            redirect_uri="https://sdk.example.com/callback",
+            is_application_custom_domain_active=False,
+        )
+
+        with patch("wristband.django_auth.config_resolver.WristbandApiClient") as mock_client_class:
+            mock_client = Mock()
+            mock_client.get_sdk_configuration = Mock(return_value=sdk_config)
+            mock_client_class.return_value = mock_client
+
+            resolver = ConfigResolver(self.config)
+
+            with pytest.raises(WristbandError) as exc_info:
+                resolver.get_login_url()
+
+            assert exc_info.value.error == "config_validation_error"
+            assert "cannot contain the" in exc_info.value.error_description
+            assert "tenant_domain" in exc_info.value.error_description
+
+
+class TestConfigResolverEdgeCases:
+    """Test cases for edge cases and integration scenarios."""
+
+    def test_boolean_handling_for_custom_domain_active(self):
+        """Test proper boolean handling for is_application_custom_domain_active."""
+        # Test explicit False
+        config = AuthConfig(
+            client_id="test_client",
+            client_secret="test_secret",
+            wristband_application_vanity_domain="test.wristband.dev",
+            is_application_custom_domain_active=False,
+        )
+        resolver = ConfigResolver(config)
+        assert resolver.get_is_application_custom_domain_active() is False
+
+        # Test explicit True
+        config = AuthConfig(
+            client_id="test_client",
+            client_secret="test_secret",
+            wristband_application_vanity_domain="test.wristband.dev",
+            is_application_custom_domain_active=True,
+        )
+        resolver = ConfigResolver(config)
+        assert resolver.get_is_application_custom_domain_active() is True
+
+        # Test None with auto-config
+        sdk_config = SdkConfiguration(
+            login_url="https://sdk.example.com/login",
+            redirect_uri="https://sdk.example.com/callback",
+            is_application_custom_domain_active=False,
+        )
+        config = AuthConfig(
+            client_id="test_client",
+            client_secret="test_secret",
+            wristband_application_vanity_domain="test.wristband.dev",
+        )
+        with patch("wristband.django_auth.config_resolver.WristbandApiClient") as mock_client_class:
+            mock_client = Mock()
+            mock_client.get_sdk_configuration = Mock(return_value=sdk_config)
+            mock_client_class.return_value = mock_client
+
+            resolver = ConfigResolver(config)
+            assert resolver.get_is_application_custom_domain_active() is False
+
+    def test_empty_string_values(self):
+        """Test handling of empty string values."""
+        sdk_config = SdkConfiguration(
+            login_url="https://sdk.example.com/login",
+            redirect_uri="https://sdk.example.com/callback",
+            custom_application_login_page_url=None,
+            is_application_custom_domain_active=True,
+        )
+
+        config = AuthConfig(
+            client_id="test_client",
+            client_secret="test_secret",
+            wristband_application_vanity_domain="test.wristband.dev",
+            custom_application_login_page_url="",
+            parse_tenant_from_root_domain="",
+        )
+
+        with patch("wristband.django_auth.config_resolver.WristbandApiClient") as mock_client_class:
+            mock_client = Mock()
+            mock_client.get_sdk_configuration = Mock(return_value=sdk_config)
+            mock_client_class.return_value = mock_client
+
+            resolver = ConfigResolver(config)
+            assert resolver.get_custom_application_login_page_url() == ""
+            assert resolver.get_parse_tenant_from_root_domain() == ""
+
+    def test_mixed_manual_and_auto_config(self):
+        """Test mixed manual and auto-configuration."""
+        sdk_config = SdkConfiguration(
+            login_url="https://sdk.example.com/login",
+            redirect_uri="https://sdk.example.com/callback",
+            custom_application_login_page_url=None,
+            is_application_custom_domain_active=False,
+            login_url_tenant_domain_suffix=None,
+        )
+
+        config = AuthConfig(
+            client_id="test_client",
+            client_secret="test_secret",
+            wristband_application_vanity_domain="test.wristband.dev",
+            login_url="https://manual.example.com/login",  # Manual override
+            # redirect_uri will come from auto-config
+        )
+
+        with patch("wristband.django_auth.config_resolver.WristbandApiClient") as mock_client_class:
+            mock_client = Mock()
+            mock_client.get_sdk_configuration = Mock(return_value=sdk_config)
+            mock_client_class.return_value = mock_client
+
+            resolver = ConfigResolver(config)
+
+            assert resolver.get_login_url() == "https://manual.example.com/login"  # Manual
+            assert resolver.get_redirect_uri() == "https://sdk.example.com/callback"  # Auto-config
+            assert resolver.get_custom_application_login_page_url() == ""  # Auto-config empty
+            assert resolver.get_parse_tenant_from_root_domain() == ""  # Auto-config empty
+
+    def test_error_preserves_original_message(self):
+        """Test that error messages preserve original exception details."""
+        with patch("wristband.django_auth.config_resolver.WristbandApiClient") as mock_client_class:
+            mock_client = Mock()
+            original_error = Exception("Network connection failed")
+            mock_client.get_sdk_configuration = Mock(side_effect=original_error)
+            mock_client_class.return_value = mock_client
+
+            config = AuthConfig(
+                client_id="test_client",
+                client_secret="test_secret",
+                wristband_application_vanity_domain="test.wristband.dev",
+            )
+            resolver = ConfigResolver(config)
+
+            with pytest.raises(WristbandError) as exc_info:
+                resolver.get_login_url()
+
+            assert "Network connection failed" in str(exc_info.value.error_description)
+
+    def test_validate_resolved_config_precedence(self):
+        """Test that manual config values take precedence in validation."""
+        # Manual config has correct tenant domain token
+        config = AuthConfig(
+            client_id="test_client",
+            client_secret="test_secret",
+            wristband_application_vanity_domain="test.wristband.dev",
+            login_url="https://{tenant_domain}.manual.com/login",
+            parse_tenant_from_root_domain="manual.com",
+        )
+
+        # SDK config would fail validation if used
+        sdk_config = SdkConfiguration(
+            login_url="https://sdk.example.com/login",  # No tenant token
+            redirect_uri="https://{tenant_domain}.sdk.com/callback",
+            is_application_custom_domain_active=True,
+        )
+
+        with patch("wristband.django_auth.config_resolver.WristbandApiClient") as mock_client_class:
+            mock_client = Mock()
+            mock_client.get_sdk_configuration = Mock(return_value=sdk_config)
+            mock_client_class.return_value = mock_client
+
+            resolver = ConfigResolver(config)
+
+            # Should not raise validation error because manual login_url is used
+            result = resolver.get_login_url()
+            assert result == "https://{tenant_domain}.manual.com/login"
+
+    def test_wristband_api_client_initialization(self):
+        """Test that WristbandApiClient is initialized correctly."""
+        config = AuthConfig(
+            client_id="test_client",
+            client_secret="test_secret",
+            wristband_application_vanity_domain="test.wristband.dev",
+        )
+
+        with patch("wristband.django_auth.config_resolver.WristbandApiClient") as mock_client_class:
+            ConfigResolver(config)
+            mock_client_class.assert_called_once_with("test.wristband.dev", "test_client", "test_secret")
+
+    def test_concurrent_thread_access(self):
+        """Test concurrent access from multiple threads."""
+        sdk_config = SdkConfiguration(
+            login_url="https://sdk.example.com/login",
+            redirect_uri="https://sdk.example.com/callback",
+            is_application_custom_domain_active=False,
+        )
+
+        with patch("wristband.django_auth.config_resolver.WristbandApiClient") as mock_client_class:
+            mock_client = Mock()
+
+            # Add delay to simulate network request
+            def delayed_response():
+                time.sleep(0.1)
+                return sdk_config
+
+            mock_client.get_sdk_configuration = Mock(side_effect=delayed_response)
+            mock_client_class.return_value = mock_client
+
+            config = AuthConfig(
+                client_id="test_client",
+                client_secret="test_secret",
+                wristband_application_vanity_domain="test.wristband.dev",
+            )
+            resolver = ConfigResolver(config)
+
+            results = []
+            exceptions = []
+
+            def worker(getter_method):
+                try:
+                    result = getattr(resolver, getter_method)()
+                    results.append(result)
+                except Exception as e:
+                    exceptions.append(e)
+
+            # Start multiple threads with different getters
+            threads = [
+                threading.Thread(target=worker, args=("get_login_url",)),
+                threading.Thread(target=worker, args=("get_redirect_uri",)),
+                threading.Thread(target=worker, args=("get_is_application_custom_domain_active",)),
+            ]
+
+            for thread in threads:
+                thread.start()
+
+            for thread in threads:
+                thread.join()
+
+            # Should only make one API call
+            mock_client.get_sdk_configuration.assert_called_once()
+            assert len(exceptions) == 0
+            assert len(results) == 3
+
+    def test_tenant_token_in_redirect_uri_without_parsing(self):
+        """Test redirect_uri validation without parsing."""
+        config = AuthConfig(
+            client_id="test_client",
+            client_secret="test_secret",
+            wristband_application_vanity_domain="test.wristband.dev",
+            auto_configure_enabled=False,
+            login_url="https://test.com/login",
+            redirect_uri="https://{tenant_domain}.test.com/callback",
+        )
+
+        with pytest.raises(TypeError, match='cannot contain the "\\{tenant_domain\\}" token'):
+            ConfigResolver(config)
+
+    def test_tenant_token_in_login_url_partial_validation(self):
+        """Test partial validation login_url without parsing."""
+        config = AuthConfig(
+            client_id="test_client",
+            client_secret="test_secret",
+            wristband_application_vanity_domain="test.wristband.dev",
+            login_url="https://{tenant_domain}.test.com/login",
+        )
+
+        with pytest.raises(TypeError, match='cannot contain the "\\{tenant_domain\\}" token'):
+            ConfigResolver(config)
+
+    def test_tenant_token_missing_in_redirect_uri_partial_validation(self):
+        """Test partial validation when redirect_uri missing tenant token but parsing enabled."""
+        config = AuthConfig(
+            client_id="test_client",
+            client_secret="test_secret",
+            wristband_application_vanity_domain="test.wristband.dev",
+            redirect_uri="https://test.com/callback",  # no tenant token
+            parse_tenant_from_root_domain="test.com",  # parsing enabled
+        )
+
+        with pytest.raises(TypeError, match='must contain the "\\{tenant_domain\\}" token'):
+            ConfigResolver(config)
+
+    def test_redirect_uri_token_present_without_parsing(self):
+        """Test redirect_uri has tenant token but parsing disabled."""
+        config = AuthConfig(
+            client_id="test_client",
+            client_secret="test_secret",
+            wristband_application_vanity_domain="test.wristband.dev",
+            redirect_uri="https://{tenant_domain}.test.com/callback",  # has tenant token
+            # parse_tenant_from_root_domain is None/empty - parsing disabled
+        )
+
+        with pytest.raises(TypeError, match='cannot contain the "\\{tenant_domain\\}" token'):
+            ConfigResolver(config)
+
+    def test_validate_resolved_redirect_uri_missing_token(self):
+        """Test resolved config validation when redirect_uri missing tenant token."""
+        sdk_config = SdkConfiguration(
+            login_url="https://{tenant_domain}.sdk.example.com/login",
+            redirect_uri="https://sdk.example.com/callback",  # missing tenant token
+            is_application_custom_domain_active=False,
+            login_url_tenant_domain_suffix="example.com",  # This enables tenant parsing
+        )
+
+        config = AuthConfig(
+            client_id="test_client",
+            client_secret="test_secret",
+            wristband_application_vanity_domain="test.wristband.dev",
+        )
+
+        with patch("wristband.django_auth.config_resolver.WristbandApiClient") as mock_client_class:
+            mock_client = Mock()
+            mock_client.get_sdk_configuration = Mock(return_value=sdk_config)
+            mock_client_class.return_value = mock_client
+
+            resolver = ConfigResolver(config)
+
+            with pytest.raises(WristbandError) as exc_info:
+                resolver.get_redirect_uri()  # This should trigger the validation
+
+            assert "must contain the" in exc_info.value.error_description
+            assert "redirect_uri" in exc_info.value.error_description
+
+    def test_validate_resolved_redirect_uri_has_token_without_parsing(self):
+        """Test resolved config validation when redirect_uri has token but parsing disabled."""
+        sdk_config = SdkConfiguration(
+            login_url="https://sdk.example.com/login",  # no tenant token
+            redirect_uri="https://{tenant_domain}.sdk.example.com/callback",  # has tenant token
+            is_application_custom_domain_active=False,
+            login_url_tenant_domain_suffix=None,  # No tenant parsing (falsy)
+        )
+
+        config = AuthConfig(
+            client_id="test_client",
+            client_secret="test_secret",
+            wristband_application_vanity_domain="test.wristband.dev",
+        )
+
+        with patch("wristband.django_auth.config_resolver.WristbandApiClient") as mock_client_class:
+            mock_client = Mock()
+            mock_client.get_sdk_configuration = Mock(return_value=sdk_config)
+            mock_client_class.return_value = mock_client
+
+            resolver = ConfigResolver(config)
+
+            with pytest.raises(WristbandError) as exc_info:
+                resolver.get_redirect_uri()
+
+            assert "cannot contain the" in exc_info.value.error_description
+            assert "redirect_uri" in exc_info.value.error_description
+
+    def test_cache_thread_safety_with_error_recovery(self):
+        """Test cache thread safety when errors occur and recovery happens."""
+        with patch("wristband.django_auth.config_resolver.WristbandApiClient") as mock_client_class:
+            mock_client = Mock()
+
+            # Track total call count across all attempts
+            total_call_count = 0
+
+            def error_then_success():
+                nonlocal total_call_count
+                total_call_count += 1
+                if total_call_count <= 3:  # First 3 calls fail
+                    raise Exception(f"Error {total_call_count}")
+                return SdkConfiguration(
+                    login_url="https://sdk.example.com/login",
+                    redirect_uri="https://sdk.example.com/callback",
+                    is_application_custom_domain_active=True,
+                )
+
+            mock_client.get_sdk_configuration = Mock(side_effect=error_then_success)
+            mock_client_class.return_value = mock_client
+
+            config = AuthConfig(
+                client_id="test_client",
+                client_secret="test_secret",
+                wristband_application_vanity_domain="test.wristband.dev",
+            )
+            resolver = ConfigResolver(config)
+
+            # First call should fail after retries
+            with pytest.raises(WristbandError):
+                resolver.get_login_url()
+
+            # Verify we made 3 attempts
+            assert total_call_count == 3
+
+            # Second call should succeed (this will be the 4th total call)
+            result = resolver.get_redirect_uri()
+            assert result == "https://sdk.example.com/callback"
+            assert total_call_count == 4  # One more call that succeeded
+
+    def test_config_validation_with_whitespace_values(self):
+        """Test config validation handles whitespace-only values correctly."""
+        config = AuthConfig(
+            client_id="test_client",
+            client_secret="test_secret",
+            wristband_application_vanity_domain="test.wristband.dev",
+            parse_tenant_from_root_domain="   ",  # whitespace only
+            login_url="https://test.com/login",
+        )
+
+        # Should treat whitespace as falsy and not require tenant token
+        resolver = ConfigResolver(config)  # Should not raise
+        assert resolver.get_parse_tenant_from_root_domain() == "   "
+
+    def test_sdk_config_fetch_with_delay_and_retry(self):
+        """Test SDK config fetch with realistic network delays and retries."""
+        with patch("wristband.django_auth.config_resolver.WristbandApiClient") as mock_client_class:
+            mock_client = Mock()
+
+            # Simulate network timeouts then success
+            def delayed_error_then_success():
+                time.sleep(0.05)  # Small delay
+                if mock_client.get_sdk_configuration.call_count <= 2:
+                    raise Exception("Network timeout")
+                return SdkConfiguration(
+                    login_url="https://sdk.example.com/login",
+                    redirect_uri="https://sdk.example.com/callback",
+                    is_application_custom_domain_active=False,
+                )
+
+            mock_client.get_sdk_configuration = Mock(side_effect=delayed_error_then_success)
+            mock_client_class.return_value = mock_client
+
+            config = AuthConfig(
+                client_id="test_client",
+                client_secret="test_secret",
+                wristband_application_vanity_domain="test.wristband.dev",
+            )
+            resolver = ConfigResolver(config)
+
+            start_time = time.time()
+            result = resolver.get_login_url()
+            end_time = time.time()
+
+            # Should succeed on third attempt
+            assert result == "https://sdk.example.com/login"
+            assert mock_client.get_sdk_configuration.call_count == 3
+            # Should have taken some time due to retries and delays
+            assert end_time - start_time >= 0.15  # 3 calls * 0.05s delay + retry delays
+
+    def test_concurrent_preload_and_get_requests(self):
+        """Test concurrent preload and getter requests with threading."""
+        sdk_config = SdkConfiguration(
+            login_url="https://sdk.example.com/login",
+            redirect_uri="https://sdk.example.com/callback",
+            is_application_custom_domain_active=False,
+        )
+
+        with patch("wristband.django_auth.config_resolver.WristbandApiClient") as mock_client_class:
+            mock_client = Mock()
+
+            # Add delay to simulate network request
+            def delayed_response():
+                time.sleep(0.1)
+                return sdk_config
+
+            mock_client.get_sdk_configuration = Mock(side_effect=delayed_response)
+            mock_client_class.return_value = mock_client
+
+            config = AuthConfig(
+                client_id="test_client",
+                client_secret="test_secret",
+                wristband_application_vanity_domain="test.wristband.dev",
+            )
+            resolver = ConfigResolver(config)
+
+            results = []
+            exceptions = []
+
+            def preload_worker():
+                try:
+                    resolver.preload_sdk_config()  # Returns None
+                    results.append(None)
+                except Exception as e:
+                    exceptions.append(e)
+
+            def getter_worker(method_name):
+                try:
+                    result = getattr(resolver, method_name)()
+                    results.append(result)
+                except Exception as e:
+                    exceptions.append(e)
+
+            # Start preload and getters concurrently
+            threads = [
+                threading.Thread(target=preload_worker),
+                threading.Thread(target=getter_worker, args=("get_login_url",)),
+                threading.Thread(target=getter_worker, args=("get_redirect_uri",)),
+            ]
+
+            for thread in threads:
+                thread.start()
+
+            for thread in threads:
+                thread.join()
+
+            # Should only make one API call
+            mock_client.get_sdk_configuration.assert_called_once()
+            assert len(exceptions) == 0
+            assert len(results) == 3
+            # Preload returns None, getters return values
+            assert None in results
+            assert "https://sdk.example.com/login" in results
+            assert "https://sdk.example.com/callback" in results


### PR DESCRIPTION
- The all new SDK auto-configuration functionality is now available. It supports both lazy and eager auto-configuration. Auto-configuration is enabled by default and will fetch missing configuration values from the Wristband SDK Configuration Endpoint when any auth method is first called. Manual configuration values take precedence over auto-configured values. Set `auto_configure_enabled` to False in the `AuthConfig` to disable.

- The new `discover()` method in `WristbandAuth` can be used to eager-load SDK configurations from the Wristband SDK Configuration Endpoint on server startup.

- The `login_state_secret` config is no longer required. If not provided, it will default to using the client secret. For enhanced security, it is recommended to provide a value that is unique from the client secret. You can run `openssl rand -base64 32` to create a secret from your CLI.

- The `LoginConfig` class for the `login()` method now supports a `return_url` field. If a value is provided, then it takes precedence over the `return_url` request query parameter.

- The `LogoutConfig` class for the `logout()` method now supports a `state` field. This is an optional value that allows you to preserve application state through the logout flow. If provided, it will be appended as a query parameter to the resolved logout URL. Maximum length of 512 characters. This is useful for tracking logout context, displaying post-logout messages, or handling different logout scenarios.