### PR TITLE
Release 0.3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,9 @@ WRISTBAND_AUTH = {
 
 Create an instance of `WristbandAuth` in a dedicated authentication module somewhere in your Django app (i.e., `your_app/wristband.py`). When creating an instance, provide all necessary Wristband configurations from your Django settings.
 
+> [!NOTE]
+> If you use Safari browser When developing and testing on `localhost`, you may need to set `dangerously_disable_secure_cookies=True`. Remember to set the value back to `False` for Production!
+
 ```python
 # your_app/wristband.py
 from django.conf import settings
@@ -186,6 +189,9 @@ SESSION_ENGINE = 'django.contrib.sessions.backends.db'
 
 Make sure to configure Django sessions to work optimally with Wristband authentication, ensuring sessions stay active during user activity and expire after periods of inactivity:
 
+> [!NOTE]
+> If you use Safari browser When developing and testing on `localhost`, you may need to set `SESSION_COOKIE_SECURE = False`. Remember to set the value back to `True` for Production!
+
 ```python
 # your_project/settings.py
 
@@ -194,7 +200,7 @@ Make sure to configure Django sessions to work optimally with Wristband authenti
 # Session configuration
 SESSION_SAVE_EVERY_REQUEST = True  # Keep a rolling session expiration time as long as user is active
 SESSION_COOKIE_AGE = 3600  # 1 hour of inactivity, adjust as needed
-SESSION_COOKIE_SECURE = True
+SESSION_COOKIE_SECURE = True  # IMPORTANT: Set to True in Production!!
 ```
 
 <br>
@@ -232,9 +238,9 @@ urlpatterns = [
     # Your other app URLs...
     
     # Wristband Auth Endpoints (URL path values can be anything you want)
-    path('auth/login/', auth_views.Login.as_view(), name='login'),
-    path('auth/callback/', auth_views.Callback.as_view(), name='callback'),
-    path('auth/logout/', auth_views.Logout.as_view(), name='logout'),
+    path('auth/login/', auth_views.login_view, name='login'),
+    path('auth/callback/', auth_views.callback_view, name='callback'),
+    path('auth/logout/', auth_views.logout_view, name='logout'),
 ]
 ```
 
@@ -247,17 +253,16 @@ The goal of the Login View/Endpoint is to initiate an auth request by redirectin
 ```python
 # your_app/auth_views.py
 from django.http import HttpRequest, HttpResponse
-from django.views import View
+from django.views.decorators.http import require_GET
 from wristband.django_auth import CallbackResultType, LogoutConfig
 
 # Import your configured Wristband auth instance
 from .wristband import wristband_auth
 
-class Login(View):
+@require_GET
+def login_view(request: HttpRequest) -> HttpResponse:
     """Initiate authentication by redirecting to Wristband"""
-    
-    def get(self, request: HttpRequest) -> HttpResponse:
-        return wristband_auth.login(request)
+    return wristband_auth.login(request)
 
 # ...
 ```
@@ -271,36 +276,35 @@ The goal of the Callback View/Endpoint is to receive incoming calls from Wristba
 ```python
 # your_app/auth_views.py
 from django.http import HttpRequest, HttpResponse
-from django.views import View
+from django.views.decorators.http import require_GET
 from wristband.django_auth import CallbackResultType, LogoutConfig
 from .wristband import wristband_auth
 
 # ...
 
-class Callback(View):
+@require_GET
+def callback_view(request: HttpRequest) -> HttpResponse:
     """Process OAuth callback and create session for authenticated user"""
-    
-    def get(self, request: HttpRequest) -> HttpResponse:
-        callback_result = wristband_auth.callback(request)
+    callback_result = wristband_auth.callback(request)
         
-        # For certain edge cases, the SDK will require you to redirect back to login
-        if callback_result.type == CallbackResultType.REDIRECT_REQUIRED:
-            return wristband_auth.create_callback_response(request, callback_result.redirect_url)
+    # For certain edge cases, the SDK will require you to redirect back to login
+    if callback_result.type == CallbackResultType.REDIRECT_REQUIRED:
+        return wristband_auth.create_callback_response(request, callback_result.redirect_url)
         
-        # Create session data for the authenticated user
-        callback_data = callback_result.callback_data
-        request.session['wristband'] = {
-            'access_token': callback_data.access_token,
-            'expires_at': callback_data.expires_at,
-            'refresh_token': callback_data.refresh_token,
-            'user_info': callback_data.user_info,
-            'tenant_domain_name': callback_data.tenant_domain_name,
-            'tenant_custom_domain': callback_data.tenant_custom_domain,
-        }
+    # Create session data for the authenticated user
+    callback_data = callback_result.callback_data
+    request.session['wristband'] = {
+        'access_token': callback_data.access_token,
+        'expires_at': callback_data.expires_at,
+        'refresh_token': callback_data.refresh_token,
+        'user_info': callback_data.user_info,
+        'tenant_domain_name': callback_data.tenant_domain_name,
+        'tenant_custom_domain': callback_data.tenant_custom_domain,
+    }
         
-        # Redirect to your app
-        post_callback_url = callback_data.return_url or '/'
-        return wristband_auth.create_callback_response(request, post_callback_url)
+    # Redirect to your app
+    post_callback_url = callback_data.return_url or '/'
+    return wristband_auth.create_callback_response(request, post_callback_url)
 
 # ...
 ```
@@ -315,34 +319,33 @@ The goal of the Logout View/Endpoint is to destroy the application's session tha
 ```python
 # your_app/auth_views.py
 from django.http import HttpRequest, HttpResponse
-from django.views import View
+from django.views.decorators.http import require_GET
 from wristband.django_auth import CallbackResultType, LogoutConfig
 from .wristband import wristband_auth
 
 # ...
 
-class Logout(View):
+@require_GET
+def logout_view(request: HttpRequest) -> HttpResponse:
     """Log out user and redirect to Wristband logout endpoint"""
-    
-    def get(self, request: HttpRequest) -> HttpResponse:
-        # Get session data for logout configuration
-        wristband_session = request.session.get('wristband', {})
+    # Get session data for logout configuration
+    wristband_session = request.session.get('wristband', {})
         
-        # Wristband SDK revokes the refresh token (if provided) and creates the proper redirect response.
-        # Wristband Logout requires a tenant level domain. Custom domains take precedence (if present).
-        response = wristband_auth.logout(
-            request, 
-            LogoutConfig(
-                refresh_token=wristband_session.get('refresh_token'),
-                tenant_domain_name=wristband_session.get('tenant_domain_name'),
-                tenant_custom_domain=wristband_session.get('tenant_custom_domain'),
-            )
+    # Wristband SDK revokes the refresh token (if provided) and creates the proper redirect response.
+    # Wristband Logout requires a tenant level domain. Custom domains take precedence (if present).
+    response = wristband_auth.logout(
+        request, 
+        LogoutConfig(
+            refresh_token=wristband_session.get('refresh_token'),
+            tenant_domain_name=wristband_session.get('tenant_domain_name'),
+            tenant_custom_domain=wristband_session.get('tenant_custom_domain'),
         )
+    )
         
-        # Destroy the user's session
-        request.session.flush()
-        
-        return response
+    # Destroy the user's session
+    request.session.flush()
+    
+    return response
 ```
 
 <br>
@@ -422,42 +425,80 @@ Now you can access authenticated session data in any template:
 
 ### 6) Protect Resources and Handle Token Refresh
 
-Create authentication middleware to protect your application views/endpoints and handle automatic token refresh. This middleware will check for valid authentication on protected routes and automatically refresh expired tokens when needed.
+When it comes to protecting your Django application, you'll mark protected endpoints that require authentication and then create custom middleware that automatically:
+
+- Determines which incoming requests need authentication
+- Ensures users have valid, active sessions
+- Automatically refreshes expired access tokens to maintain seamless user experience
+- Redirects unauthenticated users or returns appropriate error responses
+
+#### Use Decorators/Mixins on Views
+
+The SDK provides flexible authentication markers to identify your protected endpoints:
+
+- `@wristband_auth_required` decorator: Apply to function-based views that need authentication
+- `WristbandAuthRequiredMixin` mixin: Inherit in class-based views to mark them as protected
+
+These markers don't handle the actual authentication logic themselves. Instead, they serve as signals to your auth middleware, telling it which routes require user validation.
+
+**Function-Based Protected Views:**
+```python
+# your_app/protected_views.py
+from django.http import HttpRequest, HttpResponse
+from django.shortcuts import render
+from django.views.decorators.http import require_GET
+from wristband.django_auth import wristband_auth_required
+
+@wristband_auth_required
+@require_GET
+def hello_world(request: HttpRequest) -> HttpResponse:
+    """ Requires auth """
+    return render(request, "your_app/hello_world.html")
+```
+
+**Class-based Protected Views:**
+```python
+# your_app/protected_views.py
+from django.http import HttpRequest, HttpResponse
+from django.shortcuts import render
+from django.views import View
+from wristband.django_auth import WristbandAuthRequiredMixin
+
+class HelloWorld(WristbandAuthRequiredMixin, View):
+    """ Requires auth """
+    def get(self, request: HttpRequest) -> HttpResponse:
+        return render(request, "your_app/hello_world.html")
+```
+
+#### Create the Authentication Middleware
+
+Create authentication middleware to protect your application views/endpoints and handle automatic token refresh. This middleware acts as a security gateway, validating user sessions on protected routes and seamlessly managing token lifecycle to keep users authenticated.
+
+The middleware will leverage two key Wristband SDK functions:
+
+- `is_wristband_auth_required(request)`: Determines if the incoming request targets a protected endpoint
+- `refresh_token_if_expired(refresh_token, expires_at)`: Automatically refreshes expired tokens with built-in retry logic and returns updated JWTs
 
 > [!NOTE]
 > There may be applications that do not want to utilize access tokens and/or refresh tokens. If that applies to your application, then you can ignore using the `refresh_token_if_expired()` functionality.
 
-#### Create the Authentication Middleware
-
-The middleware validates user sessions and performs token refresh automatically. The Wristband SDK will make 3 attempts to refresh the token and return the latest JWTs to your server.
-
 ```python
 # your_app/auth_middleware.py
-import logging
 from typing import Optional
 from django.http import HttpRequest, HttpResponse, JsonResponse
 from django.utils.deprecation import MiddlewareMixin
 from django.shortcuts import redirect
+from wristband.django_auth import is_wristband_auth_required
 from .wristband import wristband_auth
 
 
 class AuthMiddleware(MiddlewareMixin):
     """
-    Authentication middleware that protects routes and handles token refresh
+    Authentication middleware that protects routes and handles token refresh.
     """
-    
-    # Define which paths should bypass authentication
-    # Customize these for your application
-    API_PATH_PREFIX = "/api/"
-    PUBLIC_PATH_PREFIXES = ["/auth/", "/static/"]
-    PUBLIC_EXACT_PATHS = ["/", "/robots.txt"]
-
     def process_request(self, request: HttpRequest) -> Optional[HttpResponse]:
-        path = request.path
-
         # Skip authentication for public paths
-        if (any(path.startswith(prefix) for prefix in self.PUBLIC_PATH_PREFIXES) or 
-            path in self.PUBLIC_EXACT_PATHS):
+        if not is_wristband_auth_required(request):
             return None
 
         # Validate the user's authenticated session
@@ -489,17 +530,17 @@ class AuthMiddleware(MiddlewareMixin):
         # Clear invalid session
         request.session.flush()
         
-        # Return JSON response for API requests
-        if request.path.startswith(self.API_PATH_PREFIX):
+        # You can return a JSON response for pure AJAX/API requests
+        if request.path.startswith('/api/'):
             return JsonResponse({'error': 'Authentication required'}, status=401)
 
-        # Redirect to login for page/template requests
+        # Otherwise, redirect to your Login Endpoint for page/template requests
         return redirect('/auth/login/')
 ```
 
 #### Register the Auth Middleware
 
-Add your authentication middleware to your Django settings. <ins>Place it AFTER SessionMiddleware but before any middleware that depends on authentication:</ins>
+Lastly, add your authentication middleware to your Django settings. <ins>Place it AFTER SessionMiddleware but before any middleware that depends on authentication:</ins>
 
 ```python
 # your_project/settings.py
@@ -515,7 +556,7 @@ MIDDLEWARE = [
 ]
 ```
 
-The middleware will now protect all your application routes, automatically refresh expired tokens, and handle both API and page requests appropriately.
+The middleware will now protect all your protected routes!
 
 <br>
 
@@ -538,9 +579,10 @@ import requests
 from django.http import HttpRequest, JsonResponse
 from django.views import View
 from django.utils.decorators import method_decorator
+from wristband.django_auth import WristbandAuthRequiredMixin
 
 
-class UpdateNickname(View):
+class UpdateNickname(WristbandAuthRequiredMixin, View):
     """Update user nickname via Wristband API"""
 
     def post(self, request: HttpRequest) -> JsonResponse:
@@ -580,7 +622,10 @@ Refer to the [OWASP CSRF Cheat Sheet](https://cheatsheetseries.owasp.org/cheatsh
 
 #### Register CSRF Middleware
 
-Enable CsrfViewMiddleware in your Django settings, and <ins>ensure it comes after SessionMiddleware but before AuthMiddleware</ins>:
+Enable CsrfViewMiddleware in your Django settings, and <ins>ensure it comes after SessionMiddleware but before AuthMiddleware</ins>. This ensures CSRF tokens are properly validated and synchronized with user sessions during the authentication process.
+
+> [!NOTE]
+> If you use Safari browser When developing and testing on `localhost`, you may need to set `CSRF_COOKIE_SECURE = False`. Remember to set the value back to `True` for Production!
 
 ```python
 # your_project/settings.py
@@ -596,11 +641,14 @@ MIDDLEWARE = [
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
 ]
+
+CSRF_COOKIE_AGE = 3600  # 1 hour (ensure this is the same as SESSION_COOKIE_AGE)
+CSRF_COOKIE_SECURE = True # Set to True in Production!
 ```
 
 #### Generate CSRF Token in Callback Endpoint
 
-Call `get_token()` in your callback view to generate the CSRF token and set the cookie:
+Call `get_token()` in your Callback View to generate the CSRF token and set the CSRF cookie. This ensures authenticated users receive a valid CSRF token immediately after login, enabling secure form submissions and API calls throughout their session.
 
 ```python
 # your_app/auth_views.py
@@ -612,7 +660,7 @@ class Callback(View):
     def get(self, request: HttpRequest) -> HttpResponse:
         # ... existing callback logic ...
         
-        # This creates the csrftoken cookie and stores the token in the session.
+        # This creates the csrftoken cookie and stores the token in the Django session.
         get_token(request) # <-- Add this!
         
         post_callback_url = callback_data.return_url or '/'
@@ -621,7 +669,7 @@ class Callback(View):
 
 #### Refresh CSRF Token in Auth Middleware
 
-Update your auth middleware to refresh the CSRF token on each request to keep it synchronized with the session:
+Update your auth middleware to call `getToken()` to refresh the CSRF token on each request to keep it synchronized with the session: This maintains rolling expiration for both session and CSRF cookies, ensuring they expire together and preventing authentication issues when users remain active beyond the initial timeout period.
 
 ```python
 # your_app/middleware.py
@@ -639,7 +687,7 @@ class AuthMiddleware(MiddlewareMixin):
 
 #### Clear CSRF Cookie on Logout
 
-Remove the CSRF token cookie when users log out:
+Remove the CSRF token cookie when users log out. This prevents stale CSRF tokens from persisting after logout.
 
 ```python
 # your_app/auth_views.py
@@ -708,6 +756,346 @@ This setup ensures your Wristband-authenticated sessions are protected against C
 > For complete CSRF configuration options, advanced AJAX patterns, edge cases, and troubleshooting, see Django's CSRF protection documentation.
 
 <br/>
+
+## Hybrid Authentication with Django's Built-in Auth System
+
+> [!NOTE]
+> **OPTIONAL:** This section is optional. The Wristband SDK works perfectly on its own without Django's built-in authentication system. Only implement this hybrid approach if your application needs Django User objects, groups, permissions, or admin interface integration.
+
+Many Django applications benefit from combining Wristband's multi-tenant authentication with Django's built-in user management system. This hybrid approach lets you leverage Wristband for secure, scalable authentication while using Django's familiar User model, groups, permissions, and admin interface for application-specific user management.
+This integration pattern is particularly valuable when you need to:
+
+- Map Wristband roles to Django groups for permission-based access control
+- Store additional user data beyond what Wristband provides
+- Use Django's admin interface for user management
+- Integrate with existing Django packages that expect Django User objects
+- Maintain user data locally for performance or offline scenarios
+
+The hybrid approach synchronizes Wristband user data with Django's User model during your Callback View, creating a seamless bridge between external identity management and internal application logic.
+
+To implement hybrid authentication, you'll need to handle the following steps.
+
+<br>
+
+### Enable Django Authentication Components
+
+Add Django's authentication system to your settings to enable User model, groups, permissions, and admin interface integration:
+
+```python
+# your_project/settings.py
+
+INSTALLED_APPS = [
+    "django.contrib.admin",  # <-- ADD: Enables Django admin interface for user management
+    "django.contrib.auth",   # <-- ADD: Provides User model, groups, and permissions system
+    "django.contrib.sessions",
+    # ... other apps
+]
+
+MIDDLEWARE = [
+    'django.middleware.security.SecurityMiddleware',
+    'django.contrib.sessions.middleware.SessionMiddleware',
+    'django.middleware.common.CommonMiddleware',
+    'django.middleware.csrf.CsrfViewMiddleware',
+    "django.contrib.auth.middleware.AuthenticationMiddleware",  # <-- ADD: Links request.user to Django User objects
+    'your_app.middleware.AuthMiddleware',
+    # your other middlewares ...
+]
+
+TEMPLATES = [
+    {
+        'BACKEND': 'django.template.backends.django.DjangoTemplates',
+        'DIRS': [],
+        'APP_DIRS': True,
+        'OPTIONS': {
+            'context_processors': [
+                # your other context processors...
+                "django.contrib.auth.context_processors.auth",  # <-- ADD: Makes request.user available in templates
+                'your_app.context_processors.wristband_auth', 
+            ],
+        },
+    },
+]
+```
+
+You'll need to **run database migrations** to create the necessary database tables for Django's User model, groups, and permissions system. For example:
+
+```sh
+python manage.py migrate
+```
+
+<br>
+
+### Sync Wristband Users to Django User Model and Groups
+
+Modify your Callback View to create and sync Django User objects with Wristband user data. This bridges Wristband authentication with Django's user management system, enabling you to use Django's permissions, groups, and admin interface.
+
+```python
+# your_app/auth_views.py
+from django.contrib.auth import login
+from django.contrib.auth.models import User, Group
+from django.http import HttpRequest, HttpResponse
+from django.views.decorators.http import require_GET
+from wristband.django_auth import CallbackResultType, LogoutConfig
+from .wristband import wristband_auth
+
+# ...
+
+@require_GET
+def callback_view(request: HttpRequest) -> HttpResponse:
+    callback_result = wristband_auth.callback(request)
+
+    if callback_result.type == CallbackResultType.REDIRECT_REQUIRED:
+        redirect_url = callback_result.redirect_url
+        return wristband_auth.create_callback_response(request, redirect_url)
+
+    callback_data = callback_result.callback_data
+    request.session["wristband"] = {
+        "user_info": callback_data.user_info,
+        "access_token": callback_data.access_token,
+        "refresh_token": callback_data.refresh_token,
+        "expires_at": callback_data.expires_at,
+        "tenant_domain_name": callback_data.tenant_domain_name,
+        "tenant_custom_domain": callback_data.tenant_custom_domain,
+    }
+
+    # Sync Wristband user and log them in to Django's auth system
+    _sync_and_login_django_user(request, callback_data.user_info)  # <-- ADD THIS
+
+    get_token(request)
+    post_callback_url = callback_data.return_url or "/"
+    return wristband_auth.create_callback_response(request, post_callback_url)
+
+
+def _sync_and_login_django_user(request: HttpRequest, user_info):
+    """ Create or update Django User from Wristband user data and map roles to groups. """
+    email = user_info.get('email')
+    first_name = user_info.get('given_name') or 'First Name'
+    last_name = user_info.get('family_name') or 'Last Name'
+    user_id = user_info.get('sub')
+
+    # Use Wristband user ID as username since emails can change
+    user, created = User.objects.get_or_create(
+        username=user_id,
+        defaults={
+            'email': email,
+            'first_name': first_name,
+            'last_name': last_name,
+            'is_active': True,
+        }
+    )
+    
+    # Always sync fields for existing users
+    if not created:
+        user.email = email
+        user.first_name = first_name
+        user.last_name = last_name
+
+    # NOTE: The role names "Viewers" and "Owners" are examples. 
+    # Customize these group names and role-matching logic based on your requirements.
+    user.groups.clear()
+    user.is_staff = False
+    user.is_superuser = False
+    viewer_group, _ = Group.objects.get_or_create(name='Viewers')
+    user.groups.add(viewer_group)
+
+    # Map Wristband roles to Django groups and permissions.
+    roles = user_info.get('roles', [])
+    if roles:
+        role_names = [role['name'] for role in roles]
+        has_owner_role = any(
+            role_name.startswith('app:') and role_name.endswith(':owner')
+            for role_name in role_names
+        )
+
+        # Upgrade owners to admin permissions and Owners group.
+        if has_owner_role:
+            user.groups.clear()
+            user.is_staff = True
+            user.is_superuser = True
+            owner_group, _ = Group.objects.get_or_create(name='Owners')
+            user.groups.add(owner_group)
+
+    # Save user and log into Django auth system
+    user.save()
+    login(request, user)
+    return user
+```
+
+Make sure you configure the required scopes for the SDK to ensure user profile and role data is available for synchronization:
+
+```python
+# your_app/wristband.py
+from django.conf import settings
+from wristband.django_auth import AuthConfig, WristbandAuth
+
+def _create_wristband_auth() -> WristbandAuth:
+    wristband_settings = settings.WRISTBAND_AUTH
+    
+    auth_config = AuthConfig(
+        client_id=wristband_settings['client_id'],
+        client_secret=wristband_settings['client_secret'],
+        wristband_application_vanity_domain=wristband_settings['wristband_application_vanity_domain'],
+        scopes=["openid", "offline_access", "email", "profile", "roles"],  # <-- Include profile and roles
+    )
+    return WristbandAuth(auth_config)
+```
+
+### Update Your Authentication Middleware
+
+With Django's authentication system enabled, update your middleware to work seamlessly with Django's `request.user` object while maintaining Wristband session validation and token refresh:
+
+```python
+# your_app/auth_middleware.py
+from typing import Optional
+from django.contrib.auth import logout
+from django.http import HttpRequest, HttpResponse, JsonResponse
+from django.middleware.csrf import get_token
+from django.shortcuts import redirect
+from django.utils.deprecation import MiddlewareMixin
+from wristband.django_auth import is_wristband_auth_required
+from .wristband import wristband_auth
+
+
+class AuthMiddleware(MiddlewareMixin):
+    def process_request(self, request: HttpRequest) -> Optional[HttpResponse]:
+        if not is_wristband_auth_required(request):
+            return None
+
+        # vvv ADD: Validate both Wristband session and Django authentication vvv
+        wristband_data = request.session.get("wristband")
+        if not request.user.is_authenticated or not wristband_data:
+            return self._auth_failure_response(request)
+
+        try:
+            refresh_token = wristband_data.get("refresh_token")
+            expires_at = wristband_data.get("expires_at", 0)
+            new_token_data = wristband_auth.refresh_token_if_expired(refresh_token, expires_at)
+
+            if new_token_data:
+                wristband_data.update({
+                    "access_token": new_token_data.access_token,
+                    "refresh_token": new_token_data.refresh_token,
+                    "id_token": new_token_data.id_token,
+                    "expires_at": new_token_data.expires_at,
+                })
+                request.session["wristband"] = wristband_data
+
+            get_token(request)
+
+        except Exception as e:
+            return self._auth_failure_response(request)
+
+        return None
+
+    def _auth_failure_response(self, request: HttpRequest) -> HttpResponse:
+        request.session.flush()
+
+        logout(request)  # <-- ADD: Log user out of Django auth system
+
+        if request.path.startswith("/api/"):
+            return JsonResponse({"error": "Authentication failed"}, status=401)
+
+        return redirect("/auth/login")
+```
+
+<br>
+
+### Access Django Admin Through Wristband Authentication
+
+Instead of maintaining separate admin credentials, you can configure Django's admin interface to use Wristband authentication, allowing users with appropriate permissions to access admin functionality seamlessly.
+
+This configuration provides:
+
+- Unified authentication: Admin access uses the same Wristband login flow as your application
+- Permission-based access: Only users with `is_staff=True` (owners in your role mapping) can access admin
+- Seamless experience: Users with admin permissions are automatically redirected to admin after login
+- No duplicate credentials: Eliminates the need to manage separate Django superuser accounts
+
+```python
+# your_app/admin.py
+from django.contrib import admin
+from django.contrib.auth.models import User, Group
+from django.contrib.sessions.models import Session
+from django.shortcuts import redirect
+from urllib.parse import urlencode
+
+
+class WristbandAdminSite(admin.AdminSite):
+    """Custom admin site that uses Wristband authentication instead of Django's login form."""
+    
+    site_header = "Your App Admin"
+    site_title = "Admin Portal"
+    
+    def login(self, request, extra_context=None):
+        """Redirect to Wristband login instead of showing Django's admin login form."""
+        # Build return URL to redirect back to admin after authentication
+        return_url = request.build_absolute_uri('/admin/')
+        login_url = f'/auth/login/?return_url={return_url}'
+        return redirect(login_url)
+
+
+# Create custom admin site instance
+wristband_admin_site = WristbandAdminSite(name='wristband_admin')
+
+# Register models with the custom admin site
+wristband_admin_site.register(User)
+wristband_admin_site.register(Group)
+wristband_admin_site.register(Session)
+```
+
+After creating the custom admin site, make sure to update your URL configuration to use it:
+
+```python
+# your_project/urls.py
+from django.urls import path, include
+from your_app.admin import wristband_admin_site
+
+urlpatterns = [
+    # Replace default admin with Wristband-authenticated admin
+    path('admin/', wristband_admin_site.urls),
+    # Your other URLs
+    path('', include('your_app.urls')),
+]
+```
+
+<br>
+
+### Log users out of Django
+
+When users log out, ensure you clear both Wristband and Django authentication sessions to maintain security and prevent stale authentication states:
+
+```python
+# your_app/auth_views.py
+from django.contrib.auth import logout
+from django.http import HttpRequest, HttpResponse
+from django.views.decorators.http import require_GET
+from wristband.django_auth import LogoutConfig
+from .wristband import wristband_auth
+
+# ...
+
+@require_GET
+def logout_view(request: HttpRequest) -> HttpResponse:
+    """ Log out the user and redirect to the Wristband Logout Endpoint. """
+    wristband_session = request.session.get('wristband', {})
+        
+    response = wristband_auth.logout(
+        request, 
+        LogoutConfig(
+            refresh_token=wristband_session.get('refresh_token'),
+            tenant_domain_name=wristband_session.get('tenant_domain_name'),
+            tenant_custom_domain=wristband_session.get('tenant_custom_domain'),
+        )
+    )
+
+    logout(request)  # <-- ADD: Log user out of Django's auth system
+        
+    request.session.flush()
+    response.delete_cookie("csrftoken")
+    return response
+```
+
+<br>
 
 ## Wristband Auth Configuration Options
 

--- a/README.md
+++ b/README.md
@@ -57,6 +57,12 @@ You can learn more about how authentication works in Wristband in our documentat
   - [6) Protect Resources and Handle Token Refresh](#6-protect-resources-and-handle-token-refresh)
   - [7) Pass Your Access Token to Downstream APIs](#7-pass-your-access-token-to-downstream-apis)
   - [8) Configure CSRF Protection](#8-configure-csrf-protection)
+- [Hybrid Authentication with Django's Built-in Auth System](#hybrid-authentication-with-djangos-built-in-auth-system)
+  - [Enable Django Authentication Components](#enable-django-authentication-components)
+  - [Sync Wristband Users to Django User Model and Groups](#sync-wristband-users-to-django-user-model-and-groups)
+  - [Update Your Authentication Middleware](#update-your-authentication-middleware)
+  - [Access Django Admin Through Wristband Authentication](#access-django-admin-through-wristband-authentication)
+  - [Log users out of Django](#log-users-out-of-django)
 - [Wristband Auth Configuration Options](#wristband-auth-configuration-options)
 - [API](#api)
   - [`login()`](#loginself-request-httprequest-config-optionalloginconfig---httpresponse)
@@ -763,6 +769,7 @@ This setup ensures your Wristband-authenticated sessions are protected against C
 > **OPTIONAL:** This section is optional. The Wristband SDK works perfectly on its own without Django's built-in authentication system. Only implement this hybrid approach if your application needs Django User objects, groups, permissions, or admin interface integration.
 
 Many Django applications benefit from combining Wristband's multi-tenant authentication with Django's built-in user management system. This hybrid approach lets you leverage Wristband for secure, scalable authentication while using Django's familiar User model, groups, permissions, and admin interface for application-specific user management.
+
 This integration pattern is particularly valuable when you need to:
 
 - Map Wristband roles to Django groups for permission-based access control

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "wristband-django-auth"
-version = "0.2.0"
+version = "0.3.0"
 description = "SDK for integrating your Python Django application with Wristband. Handles user authentication and token management."
 readme = "README_PYPI.md"
 license = "MIT"

--- a/src/wristband/django_auth/__init__.py
+++ b/src/wristband/django_auth/__init__.py
@@ -1,5 +1,7 @@
 from .auth import WristbandAuth
+from .decorators import wristband_auth_required
 from .exceptions import WristbandError
+from .mixins import WristbandAuthRequiredMixin
 from .models import (
     AuthConfig,
     CallbackData,
@@ -10,18 +12,21 @@ from .models import (
     TokenData,
     UserInfo,
 )
-from .utils import SessionEncryptor
+from .utils import SessionEncryptor, is_wristband_auth_required
 
 __all__ = [
-    "WristbandAuth",
     "AuthConfig",
     "CallbackData",
     "CallbackResult",
     "CallbackResultType",
+    "is_wristband_auth_required",
     "LoginConfig",
     "LogoutConfig",
+    "SessionEncryptor",
     "TokenData",
     "UserInfo",
+    "wristband_auth_required",
+    "WristbandAuth",
+    "WristbandAuthRequiredMixin",
     "WristbandError",
-    "SessionEncryptor",
 ]

--- a/src/wristband/django_auth/decorators.py
+++ b/src/wristband/django_auth/decorators.py
@@ -1,0 +1,14 @@
+from typing import Any, Callable
+
+
+def wristband_auth_required(view_func: Callable[..., Any]) -> Callable[..., Any]:
+    """
+    Decorator to mark function-based views as requiring Wristband authentication.
+
+    Usage:
+        @wristband_auth_required
+        def my_view(request):
+            return render(request, 'template.html')
+    """
+    view_func.wristband_auth_required = True  # type: ignore[attr-defined]
+    return view_func

--- a/src/wristband/django_auth/mixins.py
+++ b/src/wristband/django_auth/mixins.py
@@ -1,0 +1,10 @@
+class WristbandAuthRequiredMixin:
+    """
+    Mixin for class-based views that require Wristband authentication.
+
+    Usage:
+        class MyView(WristbandAuthRequiredMixin, TemplateView):
+            template_name = 'template.html'
+    """
+
+    pass

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -1,0 +1,186 @@
+import unittest
+from unittest.mock import Mock
+
+from wristband.django_auth.decorators import wristband_auth_required
+
+
+class TestWristbandAuthRequiredDecorator(unittest.TestCase):
+    """Test cases for the wristband_auth_required decorator."""
+
+    def test_decorator_sets_attribute(self):
+        """Test that decorator sets wristband_auth_required attribute to True."""
+
+        @wristband_auth_required
+        def dummy_view(request):
+            return "test"
+
+        self.assertTrue(hasattr(dummy_view, "wristband_auth_required"))
+        self.assertEqual(dummy_view.wristband_auth_required, True)
+
+    def test_decorator_returns_original_function(self):
+        """Test that decorator returns the original function unchanged."""
+
+        def original_view(request):
+            return "original"
+
+        decorated_view = wristband_auth_required(original_view)
+
+        # Should be the same function object
+        self.assertIs(decorated_view, original_view)
+
+    def test_decorated_function_works_normally(self):
+        """Test that decorated function still works as expected."""
+
+        @wristband_auth_required
+        def test_view(request):
+            return "Hello World"
+
+        mock_request = Mock()
+        response = test_view(mock_request)
+
+        self.assertEqual(response, "Hello World")
+
+    def test_function_name_preserved(self):
+        """Test that the original function name is preserved."""
+
+        @wristband_auth_required
+        def my_special_view(request):
+            return "test"
+
+        self.assertEqual(my_special_view.__name__, "my_special_view")
+
+    def test_function_docstring_preserved(self):
+        """Test that the original function docstring is preserved."""
+
+        @wristband_auth_required
+        def documented_view(request):
+            """This is a test view with documentation."""
+            return "test"
+
+        self.assertEqual(documented_view.__doc__, "This is a test view with documentation.")
+
+    def test_function_with_args_and_kwargs(self):
+        """Test that decorated function works with various arguments."""
+
+        @wristband_auth_required
+        def view_with_args(request, arg1, arg2=None, *args, **kwargs):
+            return f"arg1: {arg1}, arg2: {arg2}"
+
+        mock_request = Mock()
+        response = view_with_args(mock_request, "test1", arg2="test2")
+
+        self.assertEqual(response, "arg1: test1, arg2: test2")
+        # Check attribute is still set
+        self.assertTrue(view_with_args.wristband_auth_required)
+
+    def test_multiple_decorations(self):
+        """Test that function can be decorated multiple times without issues."""
+
+        def other_decorator(func):
+            func.other_attribute = "test"
+            return func
+
+        @other_decorator
+        @wristband_auth_required
+        def multi_decorated_view(request):
+            return "test"
+
+        # Both attributes should be present
+        self.assertTrue(multi_decorated_view.wristband_auth_required)
+        self.assertEqual(multi_decorated_view.other_attribute, "test")
+
+    def test_decorator_with_lambda(self):
+        """Test that decorator works with lambda functions."""
+        decorated_lambda = wristband_auth_required(lambda request: "lambda")
+
+        self.assertTrue(decorated_lambda.wristband_auth_required)
+
+        mock_request = Mock()
+        response = decorated_lambda(mock_request)
+        self.assertEqual(response, "lambda")
+
+    def test_attribute_type_is_boolean(self):
+        """Test that the attribute is specifically boolean True."""
+
+        @wristband_auth_required
+        def test_view(request):
+            return "test"
+
+        self.assertIsInstance(test_view.wristband_auth_required, bool)
+        self.assertIs(test_view.wristband_auth_required, True)
+
+    def test_decorator_is_idempotent(self):
+        """Test that applying decorator multiple times doesn't break anything."""
+
+        def original_view(request):
+            return "test"
+
+        # Apply decorator twice
+        once_decorated = wristband_auth_required(original_view)
+        twice_decorated = wristband_auth_required(once_decorated)
+
+        # Should still work and have the attribute
+        self.assertTrue(twice_decorated.wristband_auth_required)
+        self.assertIs(twice_decorated, original_view)  # Still same function object
+
+    def test_no_side_effects_on_undecorated_functions(self):
+        """Test that undecorated functions don't have the attribute."""
+
+        def undecorated_view(request):
+            return "test"
+
+        self.assertFalse(hasattr(undecorated_view, "wristband_auth_required"))
+
+    def test_function_signature_unchanged(self):
+        """Test that the function signature is not altered."""
+
+        def original_view(request, pk, slug=None):
+            return f"pk: {pk}, slug: {slug}"
+
+        decorated_view = wristband_auth_required(original_view)
+
+        # Check that we can still call with same signature
+        mock_request = Mock()
+        result = decorated_view(mock_request, "123", slug="test-slug")
+        self.assertEqual(result, "pk: 123, slug: test-slug")
+
+    def test_function_exceptions_preserved(self):
+        """Test that exceptions from the original function are preserved."""
+
+        @wristband_auth_required
+        def error_view(request):
+            raise ValueError("Test error")
+
+        mock_request = Mock()
+        with self.assertRaises(ValueError) as cm:
+            error_view(mock_request)
+
+        self.assertEqual(str(cm.exception), "Test error")
+        # Attribute should still be set
+        self.assertTrue(error_view.wristband_auth_required)
+
+    def test_function_return_values_preserved(self):
+        """Test that various return types are preserved."""
+        test_cases = [
+            ("string", "string"),
+            (42, 42),
+            ([1, 2, 3], [1, 2, 3]),
+            ({"key": "value"}, {"key": "value"}),
+            (None, None),
+        ]
+
+        for expected_return, test_input in test_cases:
+            with self.subTest(return_value=expected_return):
+
+                @wristband_auth_required
+                def test_view(request):
+                    return test_input
+
+                mock_request = Mock()
+                result = test_view(mock_request)
+                self.assertEqual(result, expected_return)
+                self.assertTrue(test_view.wristband_auth_required)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_is_wristband_auth_required.py
+++ b/tests/test_is_wristband_auth_required.py
@@ -1,0 +1,153 @@
+import unittest
+from unittest.mock import Mock, patch
+
+from wristband.django_auth.decorators import wristband_auth_required
+from wristband.django_auth.mixins import WristbandAuthRequiredMixin
+from wristband.django_auth.utils import is_wristband_auth_required
+
+
+class TestIsWristbandAuthRequired(unittest.TestCase):
+    """Test cases for the is_wristband_auth_required function."""
+
+    def setUp(self):
+        """Set up test fixtures."""
+        self.mock_request = Mock()
+        self.mock_request.path = "/test-path/"
+
+    @patch("wristband.django_auth.utils.resolve")
+    def test_returns_true_for_decorated_function_view(self, mock_resolve):
+        """Test that it returns True for function views with @wristband_auth_required decorator."""
+
+        @wristband_auth_required
+        def test_view(request):
+            return "response"
+
+        mock_resolver_match = Mock(spec=["func"])
+        mock_resolver_match.func = test_view
+        mock_resolve.return_value = mock_resolver_match
+
+        result = is_wristband_auth_required(self.mock_request)
+
+        self.assertTrue(result)
+        mock_resolve.assert_called_once_with("/test-path/")
+
+    @patch("wristband.django_auth.utils.resolve")
+    def test_returns_false_for_undecorated_function_view(self, mock_resolve):
+        """Test that it returns False for function views without decorator."""
+
+        def test_view(request):
+            return "response"
+
+        mock_resolver_match = Mock(spec=["func"])
+        mock_resolver_match.func = test_view
+        mock_resolve.return_value = mock_resolver_match
+
+        result = is_wristband_auth_required(self.mock_request)
+
+        self.assertFalse(result)
+
+    @patch("wristband.django_auth.utils.resolve")
+    def test_returns_true_for_class_view_with_mixin(self, mock_resolve):
+        """Test that it returns True for class-based views with WristbandAuthRequiredMixin."""
+
+        class TestView(WristbandAuthRequiredMixin):
+            def get(self, request):
+                return "response"
+
+        mock_view_func = Mock(spec=["view_class"])
+        mock_view_func.view_class = TestView
+
+        mock_resolver_match = Mock(spec=["func"])
+        mock_resolver_match.func = mock_view_func
+        mock_resolve.return_value = mock_resolver_match
+
+        result = is_wristband_auth_required(self.mock_request)
+
+        self.assertTrue(result)
+
+    @patch("wristband.django_auth.utils.resolve")
+    def test_returns_false_for_class_view_without_mixin(self, mock_resolve):
+        """Test that it returns False for class-based views without the mixin."""
+
+        class TestView:
+            def get(self, request):
+                return "response"
+
+        mock_view_func = Mock(spec=["view_class"])
+        mock_view_func.view_class = TestView
+
+        mock_resolver_match = Mock(spec=["func"])
+        mock_resolver_match.func = mock_view_func
+        mock_resolve.return_value = mock_resolver_match
+
+        result = is_wristband_auth_required(self.mock_request)
+
+        self.assertFalse(result)
+
+    @patch("wristband.django_auth.utils.resolve")
+    def test_returns_false_when_exception_occurs(self, mock_resolve):
+        """Test that it returns False when any exception occurs."""
+        mock_resolve.side_effect = Exception("Generic error")
+
+        result = is_wristband_auth_required(self.mock_request)
+
+        self.assertFalse(result)
+
+    @patch("wristband.django_auth.utils.resolve")
+    def test_handles_missing_view_class_attribute(self, mock_resolve):
+        """Test that it handles missing view_class attribute gracefully."""
+        mock_view_func = Mock(spec=[])
+
+        mock_resolver_match = Mock(spec=["func"])
+        mock_resolver_match.func = mock_view_func
+        mock_resolve.return_value = mock_resolver_match
+
+        result = is_wristband_auth_required(self.mock_request)
+
+        self.assertFalse(result)
+
+    @patch("wristband.django_auth.utils.resolve")
+    def test_mixin_inheritance_detection(self, mock_resolve):
+        """Test that mixin detection works with inheritance hierarchy."""
+
+        class BaseView(WristbandAuthRequiredMixin):
+            pass
+
+        class DerivedView(BaseView):
+            def get(self, request):
+                return "response"
+
+        mock_view_func = Mock(spec=["view_class"])
+        mock_view_func.view_class = DerivedView
+
+        mock_resolver_match = Mock(spec=["func"])
+        mock_resolver_match.func = mock_view_func
+        mock_resolve.return_value = mock_resolver_match
+
+        result = is_wristband_auth_required(self.mock_request)
+
+        self.assertTrue(result)
+
+    @patch("wristband.django_auth.utils.resolve")
+    def test_different_request_paths(self, mock_resolve):
+        """Test function works with different request paths."""
+
+        @wristband_auth_required
+        def test_view(request):
+            return "response"
+
+        mock_resolver_match = Mock(spec=["func"])
+        mock_resolver_match.func = test_view
+        mock_resolve.return_value = mock_resolver_match
+
+        test_paths = ["/api/test/", "/admin/users/", "/app/dashboard/", "/"]
+
+        for path in test_paths:
+            with self.subTest(path=path):
+                self.mock_request.path = path
+                result = is_wristband_auth_required(self.mock_request)
+                self.assertTrue(result)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_mixins.py
+++ b/tests/test_mixins.py
@@ -1,0 +1,252 @@
+import unittest
+from unittest.mock import Mock
+
+from wristband.django_auth.mixins import WristbandAuthRequiredMixin
+
+
+class TestWristbandAuthRequiredMixin(unittest.TestCase):
+    """Test cases for the WristbandAuthRequiredMixin."""
+
+    def test_mixin_is_class(self):
+        """Test that WristbandAuthRequiredMixin is a class."""
+        self.assertTrue(isinstance(WristbandAuthRequiredMixin, type))
+
+    def test_mixin_can_be_inherited(self):
+        """Test that the mixin can be inherited by other classes."""
+
+        class TestView(WristbandAuthRequiredMixin):
+            def get(self, request):
+                return "test response"
+
+        # Should be able to create instance
+        view = TestView()
+        self.assertIsInstance(view, WristbandAuthRequiredMixin)
+        self.assertIsInstance(view, TestView)
+
+    def test_mixin_in_inheritance_hierarchy(self):
+        """Test that mixin appears in the method resolution order."""
+
+        class MockView:
+            def dispatch(self, request):
+                return "dispatched"
+
+        class TestView(WristbandAuthRequiredMixin, MockView):
+            pass
+
+        TestView()
+
+        # Check inheritance hierarchy
+        self.assertTrue(issubclass(TestView, WristbandAuthRequiredMixin))
+        self.assertTrue(issubclass(TestView, MockView))
+        self.assertIn(WristbandAuthRequiredMixin, TestView.__mro__)
+
+    def test_mixin_inheritance_order_matters(self):
+        """Test different inheritance orders work correctly."""
+
+        class BaseView:
+            def method(self):
+                return "base"
+
+        # Mixin first
+        class TestView1(WristbandAuthRequiredMixin, BaseView):
+            pass
+
+        # Mixin second
+        class TestView2(BaseView, WristbandAuthRequiredMixin):
+            pass
+
+        view1 = TestView1()
+        view2 = TestView2()
+
+        # Both should be instances of the mixin
+        self.assertIsInstance(view1, WristbandAuthRequiredMixin)
+        self.assertIsInstance(view2, WristbandAuthRequiredMixin)
+
+        # Both should inherit base functionality
+        self.assertEqual(view1.method(), "base")
+        self.assertEqual(view2.method(), "base")
+
+    def test_mixin_with_multiple_inheritance(self):
+        """Test mixin works with multiple inheritance scenarios."""
+
+        class FirstMixin:
+            first_attr = "first"
+
+        class SecondMixin:
+            second_attr = "second"
+
+        class TestView(WristbandAuthRequiredMixin, FirstMixin, SecondMixin):
+            view_attr = "view"
+
+        view = TestView()
+
+        # Should have all attributes
+        self.assertEqual(view.first_attr, "first")
+        self.assertEqual(view.second_attr, "second")
+        self.assertEqual(view.view_attr, "view")
+
+        # Should be instance of all mixins
+        self.assertIsInstance(view, WristbandAuthRequiredMixin)
+        self.assertIsInstance(view, FirstMixin)
+        self.assertIsInstance(view, SecondMixin)
+
+    def test_mixin_doesnt_override_methods(self):
+        """Test that empty mixin doesn't interfere with method calls."""
+
+        class BaseView:
+            def get(self, request):
+                return "get response"
+
+            def post(self, request):
+                return "post response"
+
+        class TestView(WristbandAuthRequiredMixin, BaseView):
+            pass
+
+        view = TestView()
+        mock_request = Mock()
+
+        # Methods should work normally
+        self.assertEqual(view.get(mock_request), "get response")
+        self.assertEqual(view.post(mock_request), "post response")
+
+    def test_mixin_can_be_detected_with_isinstance(self):
+        """Test that isinstance works for detecting the mixin."""
+
+        class TestView(WristbandAuthRequiredMixin):
+            pass
+
+        class OtherView:
+            pass
+
+        test_view = TestView()
+        other_view = OtherView()
+
+        # isinstance should work
+        self.assertTrue(isinstance(test_view, WristbandAuthRequiredMixin))
+        self.assertFalse(isinstance(other_view, WristbandAuthRequiredMixin))
+
+    def test_mixin_can_be_detected_with_issubclass(self):
+        """Test that issubclass works for detecting the mixin."""
+
+        class TestView(WristbandAuthRequiredMixin):
+            pass
+
+        class OtherView:
+            pass
+
+        # issubclass should work
+        self.assertTrue(issubclass(TestView, WristbandAuthRequiredMixin))
+        self.assertFalse(issubclass(OtherView, WristbandAuthRequiredMixin))
+
+    def test_mixin_in_method_resolution_order(self):
+        """Test that mixin appears in MRO for inheritance checking."""
+
+        class BaseView:
+            pass
+
+        class TestView(WristbandAuthRequiredMixin, BaseView):
+            pass
+
+        # Should appear in MRO
+        mro = TestView.__mro__
+        self.assertIn(WristbandAuthRequiredMixin, mro)
+        self.assertIn(BaseView, mro)
+        self.assertIn(object, mro)  # All classes inherit from object
+
+    def test_mixin_with_custom_methods(self):
+        """Test mixin with views that have custom methods."""
+
+        class TestView(WristbandAuthRequiredMixin):
+            def custom_method(self):
+                return "custom"
+
+            def get_context_data(self):
+                return {"test": "data"}
+
+        view = TestView()
+
+        # Custom methods should work
+        self.assertEqual(view.custom_method(), "custom")
+        self.assertEqual(view.get_context_data(), {"test": "data"})
+
+        # Still should be instance of mixin
+        self.assertIsInstance(view, WristbandAuthRequiredMixin)
+
+    def test_multiple_views_with_mixin(self):
+        """Test that multiple different views can use the same mixin."""
+
+        class ListView(WristbandAuthRequiredMixin):
+            def get(self, request):
+                return "list view"
+
+        class DetailView(WristbandAuthRequiredMixin):
+            def get(self, request, pk):
+                return f"detail view {pk}"
+
+        list_view = ListView()
+        detail_view = DetailView()
+
+        # Both should be instances of the mixin
+        self.assertIsInstance(list_view, WristbandAuthRequiredMixin)
+        self.assertIsInstance(detail_view, WristbandAuthRequiredMixin)
+
+        # Both should work independently
+        mock_request = Mock()
+        self.assertEqual(list_view.get(mock_request), "list view")
+        self.assertEqual(detail_view.get(mock_request, "123"), "detail view 123")
+
+    def test_mixin_class_attributes(self):
+        """Test that class attributes work normally with the mixin."""
+
+        class TestView(WristbandAuthRequiredMixin):
+            template_name = "test.html"
+            context_object_name = "object"
+
+        view = TestView()
+
+        # Class attributes should be accessible
+        self.assertEqual(view.template_name, "test.html")
+        self.assertEqual(view.context_object_name, "object")
+        self.assertEqual(TestView.template_name, "test.html")
+
+    def test_mixin_with_init_method(self):
+        """Test mixin works with classes that have __init__ methods."""
+
+        class TestView(WristbandAuthRequiredMixin):
+            def __init__(self, custom_arg):
+                self.custom_arg = custom_arg
+
+        view = TestView("test_value")
+
+        # Should initialize correctly
+        self.assertEqual(view.custom_arg, "test_value")
+        self.assertIsInstance(view, WristbandAuthRequiredMixin)
+
+    def test_empty_mixin_has_no_methods(self):
+        """Test that the empty mixin doesn't add any methods."""
+        # Get methods from the mixin (excluding special methods)
+        mixin_methods = [method for method in dir(WristbandAuthRequiredMixin) if not method.startswith("__")]
+
+        # Should be empty (no methods defined)
+        self.assertEqual(len(mixin_methods), 0)
+
+    def test_mixin_str_and_repr(self):
+        """Test that string representations work with the mixin."""
+
+        class TestView(WristbandAuthRequiredMixin):
+            def __str__(self):
+                return "TestView instance"
+
+        view = TestView()
+
+        # String representation should work
+        self.assertEqual(str(view), "TestView instance")
+
+        # Class representation should include mixin
+        class_repr = repr(TestView)
+        self.assertIn("WristbandAuthRequiredMixin", class_repr)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
- Added the following authentication markers to identify your protected endpoints:
  - `@wristband_auth_required` decorator: Apply to function-based views that need authentication
  - `WristbandAuthRequiredMixin` mixin: Inherit in class-based views to mark them as protected

These markers don't handle the actual authentication logic themselves. Instead, they serve as signals to your auth middleware, telling it which routes require user validation.

- Added the `is_wristband_auth_required()` utility function, which determines if the incoming request targets a protected endpoint. Your auth middleware can rely on it to determine whether to validate the user's authenticated session or not.

- Added a new section to the README to show how to combine Wristband auth with Django's built-in user management system. This hybrid approach lets you leverage Wristband for secure, scalable authentication while using Django's familiar User model, groups, permissions, and admin interface for application-specific user management.

- When the `login()` function cannot resolve a tenant domain and redirects to the Tenant Discovery Page, the return URL (whether provided via `LoginConfig` or request query parameter) is now preserved by appending it as a `state` query parameter to the tenant discovery URL. This ensures the return URL persists throughout the complete authentication flow, allowing users to land at their intended destination after tenant selection and login.