### PR TITLE
Release 1.0.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "wristband-django-auth"
-version = "1.0.1"
+version = "1.0.2"
 description = "SDK for integrating your Python Django application with Wristband. Handles user authentication, session management, and token management. Optional Django Rest Framework (DRF) support included."
 readme = "README_PYPI.md"
 license = "MIT"
@@ -16,7 +16,7 @@ dependencies = [
     "cryptography>=44.0.3",
     "Django>=4.2",
     "httpx>=0.24.0",
-    "wristband-python-jwt==0.1.0",
+    "wristband-python-jwt==0.1.1",
 ]
 keywords = [
     "api",


### PR DESCRIPTION
Bump `python-jwt` version to fix `pip audit` CVE for `cryptography` dependency