### PR TITLE
Release 1.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1805,6 +1805,22 @@ GET https://customer01.yourapp.ai/auth/login?login_hint=user@wristband.dev
 
 If Wristband passes this parameter, it will be appended as part of the redirect request to the Wristband Authorize Endpoint. Typically, the email form field on the Tenant-Level Login page is pre-filled when a user has previously entered their email on the Application-Level Login Page.
 
+#### IDP Hints
+
+If you want to bypass the Wristband-hosted Tenant Login Page entirely and send users directly to a specific identity provider's login page, you can pass the `idp_hint` query parameter to your Login Endpoint:
+
+```sh
+GET https://customer01.yourapp.io/auth/login?idp_hint=google
+```
+
+The value should be the `name` field of an identity provider that is currently enabled for the tenant. When Wristband receives this hint, it checks if the provided IdP name matches an enabled identity provider for that tenant:
+
+- **Matching external IdP (e.g. `google`)** — Wristband skips the Tenant Login Page entirely and redirects the user straight to that external IdP's login page (e.g. Google's login page).
+- **Wristband IdP name** — Wristband displays the Tenant Login Page but shows only the Wristband email-based login form, hiding any external IdP buttons.
+- **Unrecognized or invalid value** — Wristband ignores the hint and displays the Tenant Login Page as normal.
+
+This is useful when your application already knows which identity provider a user should authenticate with, allowing you to skip the IdP selection step entirely and provide a more seamless login experience.
+
 #### Return URLs
 
 It is possible that users will try to access a location within your application that is not some default landing page. In those cases, they would expect to immediately land back at that desired location after logging in.  This is a better experience for the user, especially in cases where they have application URLs bookmarked for convenience.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "wristband-django-auth"
-version = "1.0.2"
+version = "1.1.0"
 description = "SDK for integrating your Python Django application with Wristband. Handles user authentication, session management, and token management. Optional Django Rest Framework (DRF) support included."
 readme = "README_PYPI.md"
 license = "MIT"
@@ -13,10 +13,10 @@ authors = [
 ]
 requires-python = ">=3.10"
 dependencies = [
-    "cryptography>=44.0.3",
+    "cryptography>=46.0.6",
     "Django>=4.2",
     "httpx>=0.24.0",
-    "wristband-python-jwt==0.1.1",
+    "wristband-python-jwt==0.1.2",
 ]
 keywords = [
     "api",

--- a/src/wristband/django_auth/auth.py
+++ b/src/wristband/django_auth/auth.py
@@ -100,6 +100,8 @@ class WristbandAuth:
         Request to begin the Authorization Code flow.
 
         The incoming HTTP request can include Wristband-specific query parameters:
+        - idp_hint: A hint to Wristband about which identity provider the user should be redirected to. When present,
+          Wristband will bypass the Tenant Login Page and send the user directly to the specified identity provider.
         - login_hint: A hint about the user's preferred login identifier. This is passed as a query
           parameter in the redirect to the Authorize URL.
         - return_url: The URL to redirect the user to after authentication.
@@ -1199,6 +1201,10 @@ class WristbandAuth:
         if len(login_hint_list) > 1:
             raise TypeError("More than one [login_hint] query parameter was encountered")
 
+        idp_hint_list = request.GET.getlist("idp_hint")
+        if len(idp_hint_list) > 1:
+            raise TypeError("More than one [idp_hint] query parameter was encountered")
+
         # Assemble necessary query params for authorization request
         query_params = {
             "client_id": config.client_id,
@@ -1212,6 +1218,8 @@ class WristbandAuth:
         }
         if login_hint_list:
             query_params["login_hint"] = login_hint_list[0]
+        if idp_hint_list:
+            query_params["idp_hint"] = idp_hint_list[0]
 
         # Separator changes to a period if using an app-level custom domain with tenant subdomains
         separator: Union[Literal["."], Literal["-"]] = "." if config.is_application_custom_domain_active else "-"

--- a/src/wristband/django_auth/config_resolver.py
+++ b/src/wristband/django_auth/config_resolver.py
@@ -168,22 +168,24 @@ class ConfigResolver:
 
     def _validate_all_dynamic_configs(self, sdk_configuration: SdkConfiguration) -> None:
         """Validate all dynamic configurations after SDK config is loaded."""
-        # Validate that required fields are present in the SDK config response
-        if not sdk_configuration.login_url:
-            raise WristbandError("sdk_config_invalid", "SDK configuration response missing required field: login_url")
-        if not sdk_configuration.redirect_uri:
-            raise WristbandError(
-                "sdk_config_invalid", "SDK configuration response missing required field: redirect_uri"
-            )
 
         # Use manual config values if provided, otherwise use SDK config values
         login_url = self.auth_config.login_url or sdk_configuration.login_url
         redirect_uri = self.auth_config.redirect_uri or sdk_configuration.redirect_uri
-
         manual_tenant_parsing = (
             self.auth_config.parse_tenant_from_root_domain and self.auth_config.parse_tenant_from_root_domain.strip()
         )
         parse_tenant_from_root_domain = manual_tenant_parsing or sdk_configuration.login_url_tenant_domain_suffix
+
+        # Validate that required fields are present in the SDK config response
+        if not login_url:
+            raise WristbandError("sdk_config_invalid", "SDK configuration response missing required field: login_url")
+        if not redirect_uri:
+            raise WristbandError(
+                "sdk_config_invalid",
+                "The [redirect_uri] could not be resolved. Provide it explicitly in your SDK config "
+                "or ensure your Wristband OAuth2 Client has a single redirect URI configured.",
+            )
 
         # Validate the tenant name placeholder logic with final resolved values
         if parse_tenant_from_root_domain:
@@ -318,7 +320,7 @@ class ConfigResolver:
         # 2. If auto-configure is enabled, get from SDK config
         if self.get_auto_configure_enabled():
             sdk_config = self._load_sdk_config()
-            return sdk_config.redirect_uri
+            return sdk_config.redirect_uri or ""
 
         # 3. This should not happen if validation is done properly
         raise TypeError("The [redirect_uri] config must have a value")

--- a/src/wristband/django_auth/models.py
+++ b/src/wristband/django_auth/models.py
@@ -76,8 +76,8 @@ class SdkConfiguration:
     """
 
     login_url: str
-    redirect_uri: str
     is_application_custom_domain_active: bool
+    redirect_uri: Optional[str] = None
     custom_application_login_page_url: Optional[str] = None
     login_url_tenant_domain_suffix: Optional[str] = None
 
@@ -94,7 +94,7 @@ class SdkConfiguration:
         """
         return SdkConfiguration(
             login_url=response["loginUrl"],
-            redirect_uri=response["redirectUri"],
+            redirect_uri=response.get("redirectUri"),
             is_application_custom_domain_active=response.get("isApplicationCustomDomainActive", False),
             custom_application_login_page_url=response.get("customApplicationLoginPageUrl"),
             login_url_tenant_domain_suffix=response.get("loginUrlTenantDomainSuffix"),

--- a/tests/auth/test_login.py
+++ b/tests/auth/test_login.py
@@ -605,6 +605,49 @@ class TestWristbandAuthGetOAuthAuthorizeUrl:
         with pytest.raises(TypeError, match="More than one \\[login_hint\\] query parameter was encountered"):
             self.wristband_auth._get_oauth_authorize_url(request, oauth_config)
 
+    def test_get_oauth_authorize_url_with_idp_hint(self) -> None:
+        """Test _get_oauth_authorize_url includes idp_hint when present."""
+        request = self.factory.get("/login?idp_hint=google")
+
+        oauth_config = OAuthAuthorizeUrlConfig(
+            client_id="test_client_id",
+            redirect_uri=self.auth_config.redirect_uri or "",
+            code_verifier="test_verifier",
+            scopes=["openid", "email", "profile"],
+            state="test_state",
+            tenant_custom_domain="custom.tenant.com",
+            tenant_name=None,
+            default_tenant_custom_domain=None,
+            default_tenant_name=None,
+            is_application_custom_domain_active=False,
+            wristband_application_vanity_domain="auth.example.com",
+        )
+
+        result = self.wristband_auth._get_oauth_authorize_url(request, oauth_config)
+
+        assert "idp_hint=google" in result
+
+    def test_get_oauth_authorize_url_multiple_idp_hints_raises_error(self) -> None:
+        """Test _get_oauth_authorize_url raises error when multiple idp_hint params exist."""
+        request = self.factory.get("/login?idp_hint=google&idp_hint=facebook")
+
+        oauth_config = OAuthAuthorizeUrlConfig(
+            client_id="test_client_id",
+            redirect_uri=self.auth_config.redirect_uri or "",
+            code_verifier="test_verifier",
+            scopes=["openid", "email", "profile"],
+            state="test_state",
+            tenant_custom_domain="custom.tenant.com",
+            tenant_name=None,
+            default_tenant_custom_domain=None,
+            default_tenant_name=None,
+            is_application_custom_domain_active=False,
+            wristband_application_vanity_domain="auth.example.com",
+        )
+
+        with pytest.raises(TypeError, match="More than one \\[idp_hint\\] query parameter was encountered"):
+            self.wristband_auth._get_oauth_authorize_url(request, oauth_config)
+
 
 class TestWristbandAuthCookieManagement:
     """Test cases for login state cookie management methods."""

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -232,7 +232,6 @@ class TestWristbandApiClientGetSdkConfiguration:
         """Test handling of malformed SDK configuration response."""
         mock_response = Mock()
         mock_response.json.return_value = {
-            "loginUrl": "https://auth.example.com/login",
             # Missing required fields to trigger SdkConfiguration.from_api_response error
         }
         mock_response.raise_for_status = Mock()

--- a/tests/test_config_resolver.py
+++ b/tests/test_config_resolver.py
@@ -696,7 +696,56 @@ class TestConfigResolverDynamicValidation:
                 resolver.get_redirect_uri()
 
             assert exc_info.value.error == "sdk_config_invalid"
-            assert "missing required field: redirect_uri" in exc_info.value.error_description
+            assert (
+                "The [redirect_uri] could not be resolved. Provide it explicitly in your SDK config "
+                "or ensure your Wristband OAuth2 Client has a single redirect URI configured."
+                in exc_info.value.error_description
+            )
+
+    def test_validate_null_redirect_uri_in_sdk_config_without_manual_override(self):
+        """Test validation fails when SDK config returns null redirect_uri and no manual override provided."""
+        null_redirect_sdk_config = SdkConfiguration(
+            login_url="https://sdk.example.com/login",
+            redirect_uri=None,
+            is_application_custom_domain_active=False,
+        )
+
+        with patch("wristband.django_auth.config_resolver.WristbandApiClient") as mock_client_class:
+            mock_client = Mock()
+            mock_client.get_sdk_configuration = Mock(return_value=null_redirect_sdk_config)
+            mock_client_class.return_value = mock_client
+
+            resolver = ConfigResolver(self.config)
+
+            with pytest.raises(WristbandError) as exc_info:
+                resolver.get_redirect_uri()
+
+            assert exc_info.value.error == "sdk_config_invalid"
+            assert "The [redirect_uri] could not be resolved" in exc_info.value.error_description
+
+    def test_manual_redirect_uri_overrides_null_sdk_redirect_uri(self):
+        """Test that manual redirect_uri succeeds when SDK config returns null (multiple redirect URIs registered)."""
+        null_redirect_sdk_config = SdkConfiguration(
+            login_url="https://sdk.example.com/login",
+            redirect_uri=None,
+            is_application_custom_domain_active=False,
+        )
+
+        config = AuthConfig(
+            client_id="test_client",
+            client_secret="test_secret",
+            wristband_application_vanity_domain="test.wristband.dev",
+            redirect_uri="https://manual.example.com/callback",
+        )
+
+        with patch("wristband.django_auth.config_resolver.WristbandApiClient") as mock_client_class:
+            mock_client = Mock()
+            mock_client.get_sdk_configuration = Mock(return_value=null_redirect_sdk_config)
+            mock_client_class.return_value = mock_client
+
+            resolver = ConfigResolver(config)
+            result = resolver.get_redirect_uri()
+            assert result == "https://manual.example.com/callback"
 
     def test_validate_resolved_config_with_tenant_name(self):
         """Test validation of resolved config with tenant name parsing."""

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -130,8 +130,8 @@ class TestSdkConfiguration:
         assert config.custom_application_login_page_url == "https://custom.example.com/login"
         assert config.login_url_tenant_domain_suffix == ".tenant.wristband.dev"
 
-    def test_sdk_configuration_minimal_required_fields(self):
-        """Test SdkConfiguration with only required fields."""
+    def test_sdk_configuration_minimal_filds(self):
+        """Test SdkConfiguration with only minimal fields."""
         config = SdkConfiguration(
             login_url="https://auth.wristband.dev/api/v1/oauth2/authorize",
             redirect_uri="https://example.com/callback",
@@ -143,6 +143,17 @@ class TestSdkConfiguration:
         assert config.is_application_custom_domain_active is False
         assert config.custom_application_login_page_url is None
         assert config.login_url_tenant_domain_suffix is None
+
+    def test_sdk_configuration_from_api_response_null_redirect_uri(self):
+        """Test SdkConfiguration.from_api_response when redirectUri is null (multiple redirect URIs registered)."""
+        api_response = {
+            "loginUrl": "https://auth.example.com/login",
+            "redirectUri": None,
+            "isApplicationCustomDomainActive": False,
+        }
+        config = SdkConfiguration.from_api_response(api_response)
+        assert config.login_url == "https://auth.example.com/login"
+        assert config.redirect_uri is None
 
     def test_sdk_configuration_from_api_response(self):
         """Test SdkConfiguration.from_api_response method."""
@@ -166,13 +177,12 @@ class TestSdkConfiguration:
         """Test SdkConfiguration.from_api_response with minimal response."""
         api_response = {
             "loginUrl": "https://auth.wristband.dev/api/v1/oauth2/authorize",
-            "redirectUri": "https://example.com/callback",
         }
 
         config = SdkConfiguration.from_api_response(api_response)
 
         assert config.login_url == "https://auth.wristband.dev/api/v1/oauth2/authorize"
-        assert config.redirect_uri == "https://example.com/callback"
+        assert config.redirect_uri is None
         assert config.is_application_custom_domain_active is False  # Default from .get()
         assert config.custom_application_login_page_url is None
         assert config.login_url_tenant_domain_suffix is None


### PR DESCRIPTION
# Release 1.1.0

## New Features

### ✨ IDP Hint Support
The `login()` flow now forwards the `idp_hint` query parameter to the Wristband Authorize Endpoint when present. This allows applications to bypass the Wristband-hosted Tenant Login Page and send users directly to a specific identity provider.

**Behavior:**
- Matching external IDP — redirects user straight to that IDP's login page (e.g. Google)
- Wristband IDP name — shows only the Wristband login form, no external IDP buttons
- Unrecognized or invalid value — ignored, login page displays as normal

## Bug Fixes

### 🐛 Fix: Explicit `redirectUri` no longer fails when OAuth2 client has multiple redirect URIs
Previously, providing `redirectUri` explicitly in the SDK config would still throw an error during auto-configuration if the Wristband OAuth2 client had multiple redirect URIs configured (causing the endpoint to return `null`). The SDK now correctly uses the manually provided value and skips the null endpoint response.